### PR TITLE
[PF-2521] Use range header to partially read files from gcs

### DIFF
--- a/service/src/main/java/bio/terra/axonserver/app/configuration/BeanConfig.java
+++ b/service/src/main/java/bio/terra/axonserver/app/configuration/BeanConfig.java
@@ -7,20 +7,9 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class BeanConfig {
-
-  @Bean
-  public WebMvcConfigurer corsConfigurer() {
-    return new WebMvcConfigurer() {
-      public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**").allowedOrigins("*").allowedMethods("*").allowedHeaders("*");
-      }
-    };
-  }
 
   @Bean("objectMapper")
   public ObjectMapper objectMapper() {

--- a/service/src/main/java/bio/terra/axonserver/app/configuration/BeanConfig.java
+++ b/service/src/main/java/bio/terra/axonserver/app/configuration/BeanConfig.java
@@ -7,9 +7,20 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class BeanConfig {
+
+  @Bean
+  public WebMvcConfigurer corsConfigurer() {
+    return new WebMvcConfigurer() {
+      public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**").allowedOrigins("*").allowedMethods("*").allowedHeaders("*");
+      }
+    };
+  }
 
   @Bean("objectMapper")
   public ObjectMapper objectMapper() {

--- a/service/src/main/java/bio/terra/axonserver/app/controller/ControllerBase.java
+++ b/service/src/main/java/bio/terra/axonserver/app/controller/ControllerBase.java
@@ -18,6 +18,10 @@ public class ControllerBase {
     this.request = request;
   }
 
+  public HttpServletRequest getServletRequest() {
+    return request;
+  }
+
   public BearerToken getToken() {
     return bearerTokenFactory.from(request);
   }

--- a/service/src/main/java/bio/terra/axonserver/app/controller/GetFileController.java
+++ b/service/src/main/java/bio/terra/axonserver/app/controller/GetFileController.java
@@ -10,8 +10,6 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.core.io.Resource;
 import org.springframework.http.HttpRange;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -43,14 +41,14 @@ public class GetFileController extends ControllerBase implements GetFileApi {
    * @return - A ResponseEntity containing the file
    */
   @Override
-  public ResponseEntity<Resource> getFile(
+  public ResponseEntity<byte[]> getFile(
       UUID workspaceId, UUID resourceId, @Nullable String convertTo) {
 
     BearerToken token = getToken();
 
     HttpRange byteRange = getByteRange();
 
-    ByteArrayResource resourceObj =
+    byte[] resourceObj =
         fileService.getFile(token, workspaceId, resourceId, null, convertTo, byteRange);
     return new ResponseEntity<>(resourceObj, HttpStatus.OK);
   }
@@ -66,14 +64,14 @@ public class GetFileController extends ControllerBase implements GetFileApi {
    * @return - A ResponseEntity containing the file
    */
   @Override
-  public ResponseEntity<Resource> getFileInBucket(
+  public ResponseEntity<byte[]> getFileInBucket(
       UUID workspaceId, UUID resourceId, String objectPath, @Nullable String convertTo) {
 
     BearerToken token = getToken();
 
     HttpRange byteRange = getByteRange();
 
-    Resource resourceObj =
+    byte[] resourceObj =
         fileService.getFile(token, workspaceId, resourceId, objectPath, convertTo, byteRange);
     return new ResponseEntity<>(resourceObj, HttpStatus.OK);
   }

--- a/service/src/main/java/bio/terra/axonserver/service/file/FileService.java
+++ b/service/src/main/java/bio/terra/axonserver/service/file/FileService.java
@@ -13,6 +13,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpRange;
 import org.springframework.stereotype.Component;
 
 /**
@@ -44,6 +45,7 @@ public class FileService {
    * @param resourceId The id of the resource that the object is in
    * @param objectPath The path to the object in the bucket. Only used if the resource is a bucket.
    * @param convertTo The format to convert the file to. If null, the file is not converted.
+   * @param byteRange The range of bytes to return. If null, the entire file is returned.
    * @return The file as a byte array
    */
   public ByteArrayResource getFile(
@@ -51,12 +53,13 @@ public class FileService {
       UUID workspaceId,
       UUID resourceId,
       @Nullable String objectPath,
-      @Nullable String convertTo) {
+      @Nullable String convertTo,
+      @Nullable HttpRange byteRange) {
 
     ResourceDescription resource =
         wsmService.getResource(token.getToken(), workspaceId, resourceId);
 
-    FileWithName fileWithName = getFileHandler(workspaceId, resource, objectPath, token);
+    FileWithName fileWithName = getFileHandler(workspaceId, resource, objectPath, byteRange, token);
     byte[] file = fileWithName.file;
     if (convertTo != null) {
       String fileExtension = FilenameUtils.getExtension(fileWithName.fileName);
@@ -69,11 +72,12 @@ public class FileService {
       UUID workspaceId,
       ResourceDescription resource,
       @Nullable String objectPath,
+      @Nullable HttpRange byteRange,
       BearerToken token) {
 
     return switch (resource.getMetadata().getResourceType()) {
-      case GCS_OBJECT -> getGcsObjectFile(workspaceId, resource, objectPath, token);
-      case GCS_BUCKET -> getGcsBucketFile(workspaceId, resource, objectPath, token);
+      case GCS_OBJECT -> getGcsObjectFile(workspaceId, resource, objectPath, byteRange, token);
+      case GCS_BUCKET -> getGcsBucketFile(workspaceId, resource, objectPath, byteRange, token);
       default -> throw new InvalidResourceTypeException(
           resource.getMetadata().getResourceType()
               + " is not a type of resource that contains files");
@@ -84,6 +88,7 @@ public class FileService {
       UUID workspaceId,
       ResourceDescription resource,
       @Nullable String objectPath,
+      @Nullable HttpRange byteRange,
       BearerToken token) {
     GoogleCredentials googleCredentials = getGoogleCredentials(workspaceId, token);
 
@@ -95,16 +100,22 @@ public class FileService {
       objectPath = resource.getResourceAttributes().getGcpGcsObject().getFileName();
     }
 
-    byte[] file = CloudStorageUtils.getBucketObject(googleCredentials, bucketName, objectPath);
+    byte[] file =
+        CloudStorageUtils.getBucketObject(googleCredentials, bucketName, objectPath, byteRange);
     return new FileWithName(file, objectPath);
   }
 
   private FileWithName getGcsBucketFile(
-      UUID workspaceId, ResourceDescription resource, String objectPath, BearerToken token) {
+      UUID workspaceId,
+      ResourceDescription resource,
+      String objectPath,
+      @Nullable HttpRange byteRange,
+      BearerToken token) {
     GoogleCredentials googleCredentials = getGoogleCredentials(workspaceId, token);
 
     String bucketName = resource.getResourceAttributes().getGcpGcsBucket().getBucketName();
-    byte[] file = CloudStorageUtils.getBucketObject(googleCredentials, bucketName, objectPath);
+    byte[] file =
+        CloudStorageUtils.getBucketObject(googleCredentials, bucketName, objectPath, byteRange);
     return new FileWithName(file, objectPath);
   }
 

--- a/service/src/main/java/bio/terra/axonserver/service/file/FileService.java
+++ b/service/src/main/java/bio/terra/axonserver/service/file/FileService.java
@@ -12,7 +12,6 @@ import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpRange;
 import org.springframework.stereotype.Component;
 
@@ -48,7 +47,7 @@ public class FileService {
    * @param byteRange The range of bytes to return. If null, the entire file is returned.
    * @return The file as a byte array
    */
-  public ByteArrayResource getFile(
+  public byte[] getFile(
       BearerToken token,
       UUID workspaceId,
       UUID resourceId,
@@ -65,7 +64,7 @@ public class FileService {
       String fileExtension = FilenameUtils.getExtension(fileWithName.fileName);
       file = convertService.convertFile(file, fileExtension, convertTo, token);
     }
-    return new ByteArrayResource(file);
+    return file;
   }
 
   private FileWithName getFileHandler(

--- a/service/src/main/java/bio/terra/axonserver/utils/CloudStorageUtils.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/CloudStorageUtils.java
@@ -86,7 +86,7 @@ public class CloudStorageUtils {
       long bytesToRead = endByteIdx - startByteIdx;
 
       BoundedByteArrayOutputStream outputStream = new BoundedByteArrayOutputStream(MAX_OBJECT_SIZE);
-      ByteBuffer buffer = ByteBuffer.allocate(MAX_BUFFER_SIZE);
+      ByteBuffer buffer = ByteBuffer.allocate((int) Math.min(MAX_BUFFER_SIZE, bytesToRead));
 
       long totalBytesRead = 0;
       int bytesRead;
@@ -95,10 +95,8 @@ public class CloudStorageUtils {
         bytesRead = buffer.position();
 
         // write bytes in buffer to output stream
-        // limit the number of bytes written to the number of bytes left to read
         buffer.flip();
-        int bufferLimit = (int) Math.min(buffer.limit(), bytesToRead - totalBytesRead);
-        outputStream.write(buffer.array(), 0, bufferLimit);
+        outputStream.write(buffer.array(), 0, buffer.limit());
 
         // clear buffer and increment bytesRead
         buffer.clear();
@@ -107,7 +105,7 @@ public class CloudStorageUtils {
 
       return outputStream.toByteArray();
     } catch (IndexOutOfBoundsException e) {
-      throw new CloudObjectReadException("Object Size Too Large: " + objectName);
+      throw new CloudObjectReadException("Object size too large: " + objectName);
     } catch (IOException e) {
       throw new CloudObjectReadException("Error reading object: " + objectName);
     }

--- a/service/src/main/java/bio/terra/axonserver/utils/CloudStorageUtils.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/CloudStorageUtils.java
@@ -22,7 +22,8 @@ import org.springframework.util.unit.DataSize;
 public class CloudStorageUtils {
 
   private static final int MAX_OBJECT_SIZE = (int) DataSize.ofMegabytes(512).toBytes();
-  private static final int MAX_BUFFER_SIZE = (int) DataSize.ofKilobytes(64).toBytes();
+  private static final int MAX_BUFFER_SIZE = 4;
+  // private static final int MAX_BUFFER_SIZE = (int) DataSize.ofKilobytes(64).toBytes();
 
   // Google pet service account scopes for accessing Google Cloud APIs.
   private static final List<String> PET_SA_SCOPES =
@@ -78,21 +79,21 @@ public class CloudStorageUtils {
               .getService()
               .reader(blobId);
 
-      long start =
+      long startByteIdx =
           Optional.ofNullable(byteRange).isPresent() ? byteRange.getRangeStart(Long.MAX_VALUE) : 0;
-      long end =
+      long endByteIdx =
           Optional.ofNullable(byteRange).isPresent()
               ? byteRange.getRangeEnd(Long.MAX_VALUE)
               : Long.MAX_VALUE - 1;
-      long length = end - start + 1;
+      long bytesToRead = endByteIdx - startByteIdx;
 
       BoundedByteArrayOutputStream outputStream = new BoundedByteArrayOutputStream(MAX_OBJECT_SIZE);
       ByteBuffer buffer = ByteBuffer.allocate(MAX_BUFFER_SIZE);
 
       long totalBytesRead = 0;
       int bytesRead;
-      reader.seek(start);
-      while (totalBytesRead < length && reader.read(buffer) > 0) {
+      reader.seek(startByteIdx);
+      while (totalBytesRead < bytesToRead && reader.read(buffer) > 0) {
         bytesRead = buffer.position();
         totalBytesRead += bytesRead;
 

--- a/service/src/main/java/bio/terra/axonserver/utils/CloudStorageUtils.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/CloudStorageUtils.java
@@ -18,9 +18,7 @@ import javax.annotation.Nullable;
 import org.springframework.http.HttpRange;
 import org.springframework.util.unit.DataSize;
 
-/**
- * Service for interacting with Google Cloud Storage
- */
+/** Service for interacting with Google Cloud Storage */
 public class CloudStorageUtils {
 
   private static final int MAX_OBJECT_SIZE = (int) DataSize.ofMegabytes(512).toBytes();
@@ -31,8 +29,7 @@ public class CloudStorageUtils {
       ImmutableList.of(
           "openid", "email", "profile", "https://www.googleapis.com/auth/cloud-platform");
 
-  public CloudStorageUtils() {
-  }
+  public CloudStorageUtils() {}
 
   public static List<String> getPetScopes() {
     return PET_SA_SCOPES;

--- a/service/src/main/java/bio/terra/axonserver/utils/CloudStorageUtils.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/CloudStorageUtils.java
@@ -93,11 +93,16 @@ public class CloudStorageUtils {
       reader.seek(startByteIdx);
       while (totalBytesRead < bytesToRead && reader.read(buffer) > 0) {
         bytesRead = buffer.position();
-        totalBytesRead += bytesRead;
 
+        // write bytes in buffer to output stream
+        // limit the number of bytes written to the number of bytes left to read
         buffer.flip();
-        outputStream.write(buffer.array(), 0, buffer.limit());
+        int bufferLimit = (int) Math.min(buffer.limit(), bytesToRead - totalBytesRead);
+        outputStream.write(buffer.array(), 0, bufferLimit);
+
+        // clear buffer and increment bytesRead
         buffer.clear();
+        totalBytesRead += bytesRead;
       }
 
       return outputStream.toByteArray();

--- a/service/src/main/java/bio/terra/axonserver/utils/CloudStorageUtils.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/CloudStorageUtils.java
@@ -18,19 +18,21 @@ import javax.annotation.Nullable;
 import org.springframework.http.HttpRange;
 import org.springframework.util.unit.DataSize;
 
-/** Service for interacting with Google Cloud Storage */
+/**
+ * Service for interacting with Google Cloud Storage
+ */
 public class CloudStorageUtils {
 
   private static final int MAX_OBJECT_SIZE = (int) DataSize.ofMegabytes(512).toBytes();
-  private static final int MAX_BUFFER_SIZE = 4;
-  // private static final int MAX_BUFFER_SIZE = (int) DataSize.ofKilobytes(64).toBytes();
+  private static final int MAX_BUFFER_SIZE = (int) DataSize.ofKilobytes(64).toBytes();
 
   // Google pet service account scopes for accessing Google Cloud APIs.
   private static final List<String> PET_SA_SCOPES =
       ImmutableList.of(
           "openid", "email", "profile", "https://www.googleapis.com/auth/cloud-platform");
 
-  public CloudStorageUtils() {}
+  public CloudStorageUtils() {
+  }
 
   public static List<String> getPetScopes() {
     return PET_SA_SCOPES;
@@ -71,13 +73,12 @@ public class CloudStorageUtils {
     }
 
     BlobId blobId = BlobId.of(bucketName, objectName);
-    try {
-      ReadChannel reader =
-          StorageOptions.newBuilder()
-              .setCredentials(googleCredentials)
-              .build()
-              .getService()
-              .reader(blobId);
+    try (ReadChannel reader =
+        StorageOptions.newBuilder()
+            .setCredentials(googleCredentials)
+            .build()
+            .getService()
+            .reader(blobId)) {
 
       long startByteIdx =
           Optional.ofNullable(byteRange).isPresent() ? byteRange.getRangeStart(Long.MAX_VALUE) : 0;
@@ -102,7 +103,6 @@ public class CloudStorageUtils {
         buffer.clear();
       }
 
-      reader.close();
       return outputStream.toByteArray();
     } catch (IndexOutOfBoundsException e) {
       throw new CloudObjectReadException("Object Size Too Large: " + objectName);

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -100,7 +100,7 @@ paths:
             text/plain:
               schema:
                 type: string
-                format: binary
+                format: byte
 
   /api/workspaces/v1/{workspaceId}/resources/{resourceId}/file/objects/{objectPath}:
     parameters:
@@ -123,7 +123,7 @@ paths:
             text/plain:
               schema:
                 type: string
-                format: binary
+                format: byte
 
 components:
   schemas:


### PR DESCRIPTION
While Spring supports range headers and returning Resource response types partially, the getFile controllers still read the entire object from gcs. This change extends `getBucketObject` in `CloudStorageUtils` to read a byte range if a range is provided by the request.

This change is needed for the use case of previewing IGV bam, sam, and cram genomics files.