### PR TITLE
Make getResource argument ordering consistent with other WSM Service calls.

### DIFF
--- a/service/src/main/java/bio/terra/axonserver/app/controller/AwsResourceController.java
+++ b/service/src/main/java/bio/terra/axonserver/app/controller/AwsResourceController.java
@@ -66,7 +66,7 @@ public class AwsResourceController extends ControllerBase implements AwsResource
 
     String accessToken = getAccessToken();
     ResourceDescription resourceDescription =
-        wsmService.getResource(accessToken, workspaceId, resourceId);
+        wsmService.getResource(workspaceId, resourceId, accessToken);
 
     AwsCredentialAccessScope accessScope =
         WorkspaceManagerService.inferAwsCredentialAccessScope(

--- a/service/src/main/java/bio/terra/axonserver/app/controller/GetFileController.java
+++ b/service/src/main/java/bio/terra/axonserver/app/controller/GetFileController.java
@@ -111,7 +111,7 @@ public class GetFileController extends ControllerBase implements GetFileApi {
     String projectId = wsmService.getGcpContext(workspaceId, accessToken).getProjectId();
     String bucketName;
     var attributes =
-        wsmService.getResource(accessToken, workspaceId, resourceId).getResourceAttributes();
+        wsmService.getResource(workspaceId, resourceId, accessToken).getResourceAttributes();
     var bucket = attributes.getGcpGcsBucket();
     if (bucket != null) {
       bucketName = bucket.getBucketName();

--- a/service/src/main/java/bio/terra/axonserver/service/file/FileService.java
+++ b/service/src/main/java/bio/terra/axonserver/service/file/FileService.java
@@ -68,7 +68,7 @@ public class FileService {
       @Nullable HttpRange byteRange) {
 
     ResourceDescription resource =
-        wsmService.getResource(token.getToken(), workspaceId, resourceId);
+        wsmService.getResource(workspaceId, resourceId, token.getToken());
 
     FileWithName fileWithName = getFileHandler(workspaceId, resource, objectPath, byteRange, token);
     InputStream fileStream = fileWithName.fileStream;

--- a/service/src/main/java/bio/terra/axonserver/service/wsm/WorkspaceManagerService.java
+++ b/service/src/main/java/bio/terra/axonserver/service/wsm/WorkspaceManagerService.java
@@ -47,15 +47,35 @@ public class WorkspaceManagerService {
   }
 
   /**
+   * Get a workspace.
+   *
+   * @param workspaceId terra workspace id
+   * @param minimumHighestRole require that user has minimum role on workspace, or null for any role
+   * @param accessToken user access token
+   * @return WSM Workspace description
+   * @throws ForbiddenException if minimumHighestRole is not null and user does not have at least
+   *     minimumHighestRole role on workspace
+   */
+  public WorkspaceDescription getWorkspace(
+      UUID workspaceId, @Nullable IamRole minimumHighestRole, String accessToken) {
+    try {
+      return new WorkspaceApi(getApiClient(accessToken))
+          .getWorkspace(workspaceId, minimumHighestRole);
+    } catch (ApiException apiException) {
+      throw new ForbiddenException("Unable to access workspace %s.".formatted(workspaceId));
+    }
+  }
+
+  /**
    * Get a resource from a workspace.
    *
-   * @param accessToken user access token
    * @param workspaceId terra workspace id
    * @param resourceId terra resource id
+   * @param accessToken user access token
    * @return WSM resource description
    * @throws NotFoundException if workspace or resource does not exist
    */
-  public ResourceDescription getResource(String accessToken, UUID workspaceId, UUID resourceId) {
+  public ResourceDescription getResource(UUID workspaceId, UUID resourceId, String accessToken) {
     try {
       return new ResourceApi(getApiClient(accessToken)).getResource(workspaceId, resourceId);
     } catch (ApiException apiException) {
@@ -89,16 +109,6 @@ public class WorkspaceManagerService {
   public IamRole getHighestRole(
       UUID workspaceId, @Nullable IamRole minimumHighestRole, String accessToken) {
     return getWorkspace(workspaceId, minimumHighestRole, accessToken).getHighestRole();
-  }
-
-  public WorkspaceDescription getWorkspace(
-      UUID workspaceId, IamRole minimumHighestRole, String accessToken) {
-    try {
-      return new WorkspaceApi(getApiClient(accessToken))
-          .getWorkspace(workspaceId, minimumHighestRole);
-    } catch (ApiException apiException) {
-      throw new ForbiddenException("Unable to access workspace %s.".formatted(workspaceId));
-    }
   }
 
   public void checkWorkspaceReadAccess(UUID workspaceId, String accessToken) {

--- a/service/src/test/java/bio/terra/axonserver/app/controller/AwsResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/axonserver/app/controller/AwsResourceControllerTest.java
@@ -61,7 +61,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
 
     // Expect the provided fake token will be passed to getResource, and return our mocked resource.
 
-    Mockito.when(wsmService.getResource(fakeToken, workspaceId, resourceId))
+    Mockito.when(wsmService.getResource(workspaceId, resourceId, fakeToken))
         .thenReturn(mockResourceDescription);
 
     // Expect the provided fake token and WS ID will be passed to getHighestRole, return a canned
@@ -146,7 +146,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
   @Test
   void getSignedConsoleUrl_resourceNotFound() throws Exception {
     Mockito.when(flagsmithService.isFeatureEnabled(featureFlag)).thenReturn(Optional.of(true));
-    Mockito.when(wsmService.getResource(fakeToken, workspaceId, resourceId))
+    Mockito.when(wsmService.getResource(workspaceId, resourceId, fakeToken))
         .thenThrow(new NotFoundException("not found"));
     mockMvc
         .perform(get(path).header("Authorization", String.format("bearer %s", fakeToken)))
@@ -156,7 +156,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
   @Test
   void getSignedConsoleUrl_internalError() throws Exception {
     Mockito.when(flagsmithService.isFeatureEnabled(featureFlag)).thenReturn(Optional.of(true));
-    Mockito.when(wsmService.getResource(fakeToken, workspaceId, resourceId))
+    Mockito.when(wsmService.getResource(workspaceId, resourceId, fakeToken))
         .thenThrow(new InternalServerErrorException("internal error"));
     mockMvc
         .perform(get(path).header("Authorization", String.format("bearer %s", fakeToken)))
@@ -170,7 +170,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
     ResourceDescription mockResourceDescription = mock(ResourceDescription.class);
 
     IamRole highestRole = IamRole.WRITER;
-    Mockito.when(wsmService.getResource(fakeToken, workspaceId, resourceId))
+    Mockito.when(wsmService.getResource(workspaceId, resourceId, fakeToken))
         .thenReturn(mockResourceDescription);
     Mockito.when(wsmService.getHighestRole(workspaceId, IamRole.READER, fakeToken))
         .thenReturn(highestRole);
@@ -194,7 +194,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
     ResourceDescription mockResourceDescription = mock(ResourceDescription.class);
 
     IamRole highestRole = IamRole.DISCOVERER;
-    Mockito.when(wsmService.getResource(fakeToken, workspaceId, resourceId))
+    Mockito.when(wsmService.getResource(workspaceId, resourceId, fakeToken))
         .thenReturn(mockResourceDescription);
     Mockito.when(wsmService.getHighestRole(workspaceId, IamRole.READER, fakeToken))
         .thenReturn(highestRole);


### PR DESCRIPTION
While working on [PR 23](https://github.com/DataBiosphere/terra-axon-server/pull/23) I noticed that most methods have `accessToken` as the last parameter, but `getResource` has it first.  I figured it would be good to be consistent, but didn't want to add noise to the PR, so doing separately.  Couple small formatting/javadoc changes too.