### PR TITLE
Fix failure message in Cromwell metadata response.

### DIFF
--- a/service/src/main/java/bio/terra/axonserver/service/cromwellworkflow/CromwellWorkflowService.java
+++ b/service/src/main/java/bio/terra/axonserver/service/cromwellworkflow/CromwellWorkflowService.java
@@ -214,7 +214,7 @@ public class CromwellWorkflowService {
                                             .start(m.getStart())
                                             .end(m.getEnd())
                                             .jobId(m.getJobId())
-                                            .failures(toApiFailureMessage(m.getFailures()))
+                                            .failures(toApiFailureMessageList(m.getFailures()))
                                             .returnCode(m.getReturnCode())
                                             .stdout(m.getStdout())
                                             .stderr(m.getStderr())
@@ -230,15 +230,20 @@ public class CromwellWorkflowService {
         .inputs(metadataResponse.getInputs())
         .outputs(metadataResponse.getOutputs())
         .calls(callMetadataMap)
-        .failures(toApiFailureMessage(metadataResponse.getFailures()));
+        .failures(toApiFailureMessageList(metadataResponse.getFailures()));
   }
 
-  private static ApiFailureMessage toApiFailureMessage(CromwellApiFailureMessage failureMessage) {
+  private static List<ApiFailureMessage> toApiFailureMessageList(
+      List<CromwellApiFailureMessage> failureMessage) {
     if (failureMessage == null) {
       return null;
     }
-    return new ApiFailureMessage()
-        .failure(failureMessage.getFailure())
-        .timestamp(failureMessage.getTimestamp());
+    return failureMessage.stream()
+        .map(
+            failure ->
+                new ApiFailureMessage()
+                    .message(failure.getMessage())
+                    .causedBy(toApiFailureMessageList(failure.getCausedBy())))
+        .toList();
   }
 }

--- a/service/src/main/java/bio/terra/axonserver/service/cromwellworkflow/CromwellWorkflowService.java
+++ b/service/src/main/java/bio/terra/axonserver/service/cromwellworkflow/CromwellWorkflowService.java
@@ -2,7 +2,7 @@ package bio.terra.axonserver.service.cromwellworkflow;
 
 import bio.terra.axonserver.app.configuration.CromwellConfiguration;
 import bio.terra.axonserver.model.ApiCallMetadata;
-import bio.terra.axonserver.model.ApiFailureMessage;
+import bio.terra.axonserver.model.ApiFailureMessages;
 import bio.terra.axonserver.model.ApiWorkflowMetadataResponse;
 import bio.terra.axonserver.model.ApiWorkflowMetadataResponseSubmittedFiles;
 import bio.terra.axonserver.model.ApiWorkflowQueryResponse;
@@ -13,7 +13,7 @@ import bio.terra.cromwell.api.WorkflowsApi;
 import bio.terra.cromwell.client.ApiClient;
 import bio.terra.cromwell.client.ApiException;
 import io.swagger.client.model.CromwellApiCallMetadata;
-import io.swagger.client.model.CromwellApiFailureMessage;
+import io.swagger.client.model.CromwellApiFailureMessages;
 import io.swagger.client.model.CromwellApiLabelsResponse;
 import io.swagger.client.model.CromwellApiWorkflowIdAndStatus;
 import io.swagger.client.model.CromwellApiWorkflowMetadataResponse;
@@ -216,7 +216,7 @@ public class CromwellWorkflowService {
                                             .start(m.getStart())
                                             .end(m.getEnd())
                                             .jobId(m.getJobId())
-                                            .failures(toApiFailureMessageList(m.getFailures()))
+                                            .failures(toApiFailureMessages(m.getFailures()))
                                             .returnCode(m.getReturnCode())
                                             .callRoot(m.getCallRoot())
                                             .stdout(m.getStdout())
@@ -249,20 +249,20 @@ public class CromwellWorkflowService {
         .outputs(metadataResponse.getOutputs())
         .submittedFiles(submittedFiles)
         .calls(callMetadataMap)
-        .failures(toApiFailureMessageList(metadataResponse.getFailures()));
+        .failures(toApiFailureMessages(metadataResponse.getFailures()));
   }
 
-  private static List<ApiFailureMessage> toApiFailureMessageList(
-      List<CromwellApiFailureMessage> failureMessage) {
-    if (failureMessage == null) {
+  private static List<ApiFailureMessages> toApiFailureMessages(
+      List<CromwellApiFailureMessages> failureMessages) {
+    if (failureMessages == null) {
       return null;
     }
-    return failureMessage.stream()
+    return failureMessages.stream()
         .map(
             failure ->
-                new ApiFailureMessage()
+                new ApiFailureMessages()
                     .message(failure.getMessage())
-                    .causedBy(toApiFailureMessageList(failure.getCausedBy())))
+                    .causedBy(toApiFailureMessages(failure.getCausedBy())))
         .toList();
   }
 }

--- a/service/src/main/resources/api/cromwell-openapi.yaml
+++ b/service/src/main/resources/api/cromwell-openapi.yaml
@@ -988,7 +988,7 @@ definitions:
       failures:
         type: array
         items:
-          $ref: '#/definitions/FailureMessage'
+          $ref: '#/definitions/FailureMessages'
   CallMetadata:
     description: Call level metadata
     required:
@@ -1021,7 +1021,7 @@ definitions:
       failures:
         type: array
         items:
-          $ref: '#/definitions/FailureMessage'
+          $ref: '#/definitions/FailureMessages'
       returnCode:
         type: integer
         description: Call execution return code
@@ -1036,14 +1036,14 @@ definitions:
       backendLogs:
         type: object
         description: Paths to backend specific logs for this call
-  FailureMessage:
+  FailureMessages:
     description: Failure messages
     type: object
     properties:
       causedBy:
         type: array
         items:
-          $ref: "#/definitions/FailureMessage"
+          $ref: "#/definitions/FailureMessages"
       message:
         type: string
         description: The error message.

--- a/service/src/main/resources/api/cromwell-openapi.yaml
+++ b/service/src/main/resources/api/cromwell-openapi.yaml
@@ -968,7 +968,9 @@ definitions:
           items:
             $ref: "#/definitions/CallMetadata"
       failures:
-        $ref: '#/definitions/FailureMessage'
+        type: array
+        items:
+          $ref: '#/definitions/FailureMessage'
   CallMetadata:
     description: Call level metadata
     required:
@@ -999,7 +1001,9 @@ definitions:
         type: string
         description: Backend-specific job ID
       failures:
-        $ref: '#/definitions/FailureMessage'
+        type: array
+        items:
+          $ref: '#/definitions/FailureMessage'
       returnCode:
         type: integer
         description: Call execution return code
@@ -1014,17 +1018,15 @@ definitions:
         description: Paths to backend specific logs for this call
   FailureMessage:
     description: Failure messages
-    required:
-      - failure
-      - timestamp
+    type: object
     properties:
-      failure:
+      causedBy:
+        type: array
+        items:
+          $ref: "#/definitions/FailureMessage"
+      message:
         type: string
-        description: The failure message
-      timestamp:
-        type: string
-        format: date-time
-        description: The time at which this failure occurred
+        description: The error message.
   WorkflowDescription:
     required:
       - valid

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -513,7 +513,7 @@ components:
         failures:
           type: array
           items:
-            $ref: '#/components/schemas/FailureMessage'
+            $ref: '#/components/schemas/FailureMessages'
 
     CallMetadata:
       description: Call level metadata
@@ -544,7 +544,7 @@ components:
         failures:
           type: array
           items:
-            $ref: '#/components/schemas/FailureMessage'
+            $ref: '#/components/schemas/FailureMessages'
         returnCode:
           type: integer
           description: Call execution return code
@@ -560,14 +560,14 @@ components:
           type: object
           description: Paths to backend specific logs for this call
 
-    FailureMessage:
+    FailureMessages:
       description: Failure messages
       type: object
       properties:
         causedBy:
           type: array
           items:
-            $ref: "#/components/schemas/FailureMessage"
+            $ref: "#/components/schemas/FailureMessages"
         message:
           type: string
           description: The error message.

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -494,7 +494,9 @@ components:
             items:
               $ref: "#/components/schemas/CallMetadata"
         failures:
-          $ref: '#/components/schemas/FailureMessage'
+          type: array
+          items:
+            $ref: '#/components/schemas/FailureMessage'
 
     CallMetadata:
       description: Call level metadata
@@ -523,7 +525,9 @@ components:
           type: string
           description: Backend-specific job ID
         failures:
-          $ref: '#/components/schemas/FailureMessage'
+          type: array
+          items:
+            $ref: '#/components/schemas/FailureMessage'
         returnCode:
           type: integer
           description: Call execution return code
@@ -539,16 +543,15 @@ components:
 
     FailureMessage:
       description: Failure messages
-      required: [failure, timestamp]
       type: object
       properties:
-        failure:
+        causedBy:
+          type: array
+          items:
+            $ref: "#/components/schemas/FailureMessage"
+        message:
           type: string
-          description: The failure message
-        timestamp:
-          type: string
-          format: date-time
-          description: The at which this failure occurred
+          description: The error message.
 
     WorkflowQueryResponse:
       description: Response to a workflow query


### PR DESCRIPTION
Failure message has a recursive definition. And the "failures" are a list of failure messages.