### PR TITLE
Make operation ids unique for notebook apis

### DIFF
--- a/service/src/main/java/bio/terra/axonserver/app/controller/AwsResourceController.java
+++ b/service/src/main/java/bio/terra/axonserver/app/controller/AwsResourceController.java
@@ -104,40 +104,43 @@ public class AwsResourceController extends ControllerBase implements AwsResource
   }
 
   /**
-   * Start a notebook instance
+   * Start a sagemaker notebook instance
    *
    * @param workspaceId Terra Workspace ID
    * @param resourceId Terra AWS Resource ID
    * @param wait wait for operation to complete
    */
   @Override
-  public ResponseEntity<Void> putNotebookStart(UUID workspaceId, UUID resourceId, Boolean wait) {
+  public ResponseEntity<Void> putSageMakerNotebookStart(
+      UUID workspaceId, UUID resourceId, Boolean wait) {
     getNotebook(workspaceId, resourceId).start(wait);
     return ResponseEntity.ok().build();
   }
 
   /**
-   * Stop a notebook instance
+   * Stop a sagemaker notebook instance
    *
    * @param workspaceId Terra Workspace ID
    * @param resourceId Terra AWS Resource ID
    * @param wait wait for operation to complete
    */
   @Override
-  public ResponseEntity<Void> putNotebookStop(UUID workspaceId, UUID resourceId, Boolean wait) {
+  public ResponseEntity<Void> putSageMakerNotebookStop(
+      UUID workspaceId, UUID resourceId, Boolean wait) {
     getNotebook(workspaceId, resourceId).stop(wait);
     return ResponseEntity.ok().build();
   }
 
   /**
-   * Get notebook status.
+   * Get sagemaker notebook status.
    *
    * @param workspaceId Terra Workspace ID
    * @param resourceId Terra AWS Resource ID
    * @return notebook status
    */
   @Override
-  public ResponseEntity<ApiNotebookStatus> getNotebookStatus(UUID workspaceId, UUID resourceId) {
+  public ResponseEntity<ApiNotebookStatus> getSageMakerNotebookStatus(
+      UUID workspaceId, UUID resourceId) {
     NotebookStatus notebookStatus = getNotebook(workspaceId, resourceId).getStatus();
 
     ApiNotebookStatus.NotebookStatusEnum outEnum =
@@ -149,14 +152,15 @@ public class AwsResourceController extends ControllerBase implements AwsResource
   }
 
   /**
-   * Get notebook proxy URL.
+   * Get sagemaker notebook proxy URL.
    *
    * @param workspaceId Terra Workspace ID
    * @param resourceId Terra AWS Resource ID
    * @return url to access notebook
    */
   @Override
-  public ResponseEntity<ApiSignedUrlReport> getNotebookProxyUrl(UUID workspaceId, UUID resourceId) {
+  public ResponseEntity<ApiSignedUrlReport> getSageMakerNotebookProxyUrl(
+      UUID workspaceId, UUID resourceId) {
     String proxyUrl = getNotebook(workspaceId, resourceId).getProxyUrl();
     return new ResponseEntity<>(new ApiSignedUrlReport().signedUrl(proxyUrl), HttpStatus.OK);
   }

--- a/service/src/main/java/bio/terra/axonserver/app/controller/GcpResourceController.java
+++ b/service/src/main/java/bio/terra/axonserver/app/controller/GcpResourceController.java
@@ -38,40 +38,40 @@ public class GcpResourceController extends ControllerBase implements GcpResource
   }
 
   /**
-   * Start a notebook instance
+   * Start an ai notebook instance
    *
    * @param workspaceId Terra Workspace ID
    * @param resourceId Terra AWS Resource ID
    * @param wait wait for operation to complete
    */
   @Override
-  public ResponseEntity<Void> putNotebookStart(UUID workspaceId, UUID resourceId, Boolean wait) {
+  public ResponseEntity<Void> putAiNotebookStart(UUID workspaceId, UUID resourceId, Boolean wait) {
     getNotebook(workspaceId, resourceId).start(wait);
     return ResponseEntity.ok().build();
   }
 
   /**
-   * Stop a notebook instance
+   * Stop an ai notebook instance
    *
    * @param workspaceId Terra Workspace ID
    * @param resourceId Terra AWS Resource ID
    * @param wait wait for operation to complete
    */
   @Override
-  public ResponseEntity<Void> putNotebookStop(UUID workspaceId, UUID resourceId, Boolean wait) {
+  public ResponseEntity<Void> putAiNotebookStop(UUID workspaceId, UUID resourceId, Boolean wait) {
     getNotebook(workspaceId, resourceId).stop(wait);
     return ResponseEntity.ok().build();
   }
 
   /**
-   * Get notebook status.
+   * Get ai notebook status.
    *
    * @param workspaceId Terra Workspace ID
    * @param resourceId Terra AWS Resource ID
    * @return notebook status
    */
   @Override
-  public ResponseEntity<ApiNotebookStatus> getNotebookStatus(UUID workspaceId, UUID resourceId) {
+  public ResponseEntity<ApiNotebookStatus> getAiNotebookStatus(UUID workspaceId, UUID resourceId) {
     NotebookStatus notebookStatus = getNotebook(workspaceId, resourceId).getStatus();
 
     ApiNotebookStatus.NotebookStatusEnum outEnum =
@@ -83,14 +83,15 @@ public class GcpResourceController extends ControllerBase implements GcpResource
   }
 
   /**
-   * Get notebook proxy URL.
+   * Get ai notebook proxy URL.
    *
    * @param workspaceId Terra Workspace ID
    * @param resourceId Terra AWS Resource ID
    * @return url to access notebook
    */
   @Override
-  public ResponseEntity<ApiSignedUrlReport> getNotebookProxyUrl(UUID workspaceId, UUID resourceId) {
+  public ResponseEntity<ApiSignedUrlReport> getAiNotebookProxyUrl(
+      UUID workspaceId, UUID resourceId) {
     String proxyUrl = getNotebook(workspaceId, resourceId).getProxyUrl();
     return new ResponseEntity<>(new ApiSignedUrlReport().signedUrl(proxyUrl), HttpStatus.OK);
   }

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -184,7 +184,7 @@ paths:
           default: false
     put:
       summary: Starts an AWS SageMaker Notebook Instance
-      operationId: putNotebookStart
+      operationId: putSageMakerNotebookStart
       tags: [ AwsResource ]
       responses:
         "200":
@@ -212,7 +212,7 @@ paths:
           default: false
     put:
       summary: Stop an AWS SageMaker Notebook Instance
-      operationId: putNotebookStop
+      operationId: putSageMakerNotebookStop
       tags: [ AwsResource ]
       responses:
         "200":
@@ -234,7 +234,7 @@ paths:
       - $ref: "#/components/parameters/ResourceId"
     get:
       summary: Get status of an AWS SageMaker Notebook Instance
-      operationId: getNotebookStatus
+      operationId: getSageMakerNotebookStatus
       tags: [ AwsResource ]
       responses:
         "200":
@@ -256,7 +256,7 @@ paths:
       - $ref: "#/components/parameters/ResourceId"
     get:
       summary: Get a signed Proxy URL to access an AWS SageMaker Notebook Instance
-      operationId: getNotebookProxyUrl
+      operationId: getSageMakerNotebookProxyUrl
       tags: [ AwsResource ]
       responses:
         "200":
@@ -284,7 +284,7 @@ paths:
           default: false
     put:
       summary: Starts a GCP Vertex AI Notebook Instance
-      operationId: putNotebookStart
+      operationId: putAiNotebookStart
       tags: [ GcpResource ]
       responses:
         "200":
@@ -312,7 +312,7 @@ paths:
           default: false
     put:
       summary: Stop a GCP Vertex AI Notebook Instance
-      operationId: putNotebookStop
+      operationId: putAiNotebookStop
       tags: [ GcpResource ]
       responses:
         "200":
@@ -334,7 +334,7 @@ paths:
       - $ref: "#/components/parameters/ResourceId"
     get:
       summary: Get status of a GCP Vertex AI Notebook Instance
-      operationId: getNotebookStatus
+      operationId: getAiNotebookStatus
       tags: [ GcpResource ]
       responses:
         "200":
@@ -356,7 +356,7 @@ paths:
       - $ref: "#/components/parameters/ResourceId"
     get:
       summary: Get a signed Proxy URL to access a GCP Vertex AI Notebook Instance
-      operationId: getNotebookProxyUrl
+      operationId: getAiNotebookProxyUrl
       tags: [ GcpResource ]
       responses:
         "200":


### PR DESCRIPTION
The typescript openapi client expects operation ids to be globally unique. Otherwise, the generated client contains a bunch of import naming conflicts and can't compile properly.