### PR TITLE
Add missing vertex ai notebook state

### DIFF
--- a/service/src/main/java/bio/terra/axonserver/utils/notebook/NotebookStatus.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/notebook/NotebookStatus.java
@@ -7,6 +7,7 @@ package bio.terra.axonserver.utils.notebook;
  */
 public enum NotebookStatus {
   ACTIVE,
+  CREATING,
   DELETED,
   DELETING,
   FAILED,

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -657,6 +657,7 @@ components:
           type: string
           enum:
             - ACTIVE
+            - CREATING
             - DELETED
             - DELETING
             - FAILED


### PR DESCRIPTION
Missing vertex AI state `CREATING` in notebook status enum. While the UI currently doesn't use this API to get notebook status yet, I'm using the generated enum as to validate notebook state for both aws and gcp notebooks.