### PR TITLE
Workflow endpoint fixes

### DIFF
--- a/service/src/main/java/bio/terra/axonserver/app/configuration/BeanConfig.java
+++ b/service/src/main/java/bio/terra/axonserver/app/configuration/BeanConfig.java
@@ -2,6 +2,7 @@ package bio.terra.axonserver.app.configuration;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
@@ -17,6 +18,7 @@ public class BeanConfig {
         .registerModule(new ParameterNamesModule())
         .registerModule(new Jdk8Module())
         .registerModule(new JavaTimeModule())
+        .setDateFormat(new ISO8601DateFormat())
         .setDefaultPropertyInclusion(JsonInclude.Include.NON_ABSENT);
   }
 }

--- a/service/src/main/java/bio/terra/axonserver/service/cromwellworkflow/CromwellWorkflowService.java
+++ b/service/src/main/java/bio/terra/axonserver/service/cromwellworkflow/CromwellWorkflowService.java
@@ -2,6 +2,7 @@ package bio.terra.axonserver.service.cromwellworkflow;
 
 import bio.terra.axonserver.app.configuration.CromwellConfiguration;
 import bio.terra.axonserver.model.ApiCallMetadata;
+import bio.terra.axonserver.model.ApiCallMetadataCallCaching;
 import bio.terra.axonserver.model.ApiFailureMessages;
 import bio.terra.axonserver.model.ApiWorkflowMetadataResponse;
 import bio.terra.axonserver.model.ApiWorkflowMetadataResponseSubmittedFiles;
@@ -391,21 +392,37 @@ public class CromwellWorkflowService {
                         entry ->
                             entry.getValue().stream()
                                 .map(
-                                    m ->
-                                        new ApiCallMetadata()
-                                            .inputs(m.getInputs())
-                                            .executionStatus(m.getExecutionStatus())
-                                            .backend(m.getBackend())
-                                            .backendStatus(m.getBackendStatus())
-                                            .start(m.getStart())
-                                            .end(m.getEnd())
-                                            .jobId(m.getJobId())
-                                            .failures(toApiFailureMessages(m.getFailures()))
-                                            .returnCode(m.getReturnCode())
-                                            .callRoot(m.getCallRoot())
-                                            .stdout(m.getStdout())
-                                            .stderr(m.getStderr())
-                                            .backendLogs(m.getBackendLogs()))
+                                    m -> {
+                                      ApiCallMetadata apiCallMetadata =
+                                          new ApiCallMetadata()
+                                              .inputs(m.getInputs())
+                                              .executionStatus(m.getExecutionStatus())
+                                              .backend(m.getBackend())
+                                              .backendStatus(m.getBackendStatus())
+                                              .start(m.getStart())
+                                              .end(m.getEnd())
+                                              .jobId(m.getJobId())
+                                              .failures(toApiFailureMessages(m.getFailures()))
+                                              .returnCode(m.getReturnCode())
+                                              .callRoot(m.getCallRoot())
+                                              .stdout(m.getStdout())
+                                              .stderr(m.getStderr())
+                                              .backendLogs(m.getBackendLogs());
+
+                                      if (m.getCallCaching() != null) {
+                                        apiCallMetadata.callCaching(
+                                            new ApiCallMetadataCallCaching()
+                                                .allowResultReuse(
+                                                    m.getCallCaching().isAllowResultReuse())
+                                                .effectiveCallCachingMode(
+                                                    m.getCallCaching()
+                                                        .getEffectiveCallCachingMode())
+                                                .hit(m.getCallCaching().isHit())
+                                                .result(m.getCallCaching().getResult()));
+                                      }
+
+                                      return apiCallMetadata;
+                                    })
                                 .toList()));
 
     CromwellApiWorkflowMetadataResponseSubmittedFiles cromwellSubmittedFiles =

--- a/service/src/main/resources/api/cromwell-openapi.yaml
+++ b/service/src/main/resources/api/cromwell-openapi.yaml
@@ -1036,6 +1036,21 @@ definitions:
       backendLogs:
         type: object
         description: Paths to backend specific logs for this call
+      callCaching:
+        type: object
+        properties:
+          allowResultReuse:
+            type: boolean
+            example: true
+          effectiveCallCachingMode:
+            type: string
+            example: 'ReadAndWriteCache'
+          hit:
+            type: boolean
+            example: true
+          result:
+            type: string
+            example: 'Cache Hit: 7861a17a-1069-415c-b1d1-ac28b44fdc8d:hello_world.hello:-1'
   FailureMessages:
     description: Failure messages
     type: object

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -914,12 +914,16 @@ components:
           properties:
             allowResultReuse:
               type: boolean
+              example: true
             effectiveCallCachingMode:
               type: string
+              example: 'ReadAndWriteCache'
             hit:
               type: boolean
+              example: true
             result:
               type: string
+              example: 'Cache Hit: 7861a17a-1069-415c-b1d1-ac28b44fdc8d:hello_world.hello:-1'
 
     FailureMessages:
       description: Failure messages

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -831,13 +831,13 @@ components:
             jesGcsRoot:
               type: string
             deleteIntermediateOutputFiles:
-              type: string
+              type: boolean
             memoryRetryMultiplier:
-              type: string
+              type: number
             writeToCache:
-              type: string
+              type: boolean
             readFromCache:
-              type: string
+              type: boolean
             finalWorkflowLogDir:
               type: string
             finalCallLogsDir:


### PR DESCRIPTION
Endpoint is still only used in dev, ok to change without making a new version.
* Fix datetime serialization, was previously returning milliseconds, we want iso 8601
* Fix boolean/number typings on workflow options
* Add callCaching to metadata response