### PR TITLE
Fix dataproc get component url endpoint

### DIFF
--- a/service/src/main/java/bio/terra/axonserver/app/controller/GcpResourceController.java
+++ b/service/src/main/java/bio/terra/axonserver/app/controller/GcpResourceController.java
@@ -165,7 +165,7 @@ public class GcpResourceController extends ControllerBase implements GcpResource
    *
    * @param workspaceId Terra Workspace ID
    * @param resourceId Terra Resource ID
-   * @parm componentKey Dataproc optional component key
+   * @param componentKey Dataproc optional component key
    * @return url to access component web UI
    */
   @Override

--- a/service/src/main/java/bio/terra/axonserver/app/controller/GcpResourceController.java
+++ b/service/src/main/java/bio/terra/axonserver/app/controller/GcpResourceController.java
@@ -2,7 +2,6 @@ package bio.terra.axonserver.app.controller;
 
 import bio.terra.axonserver.api.GcpResourceApi;
 import bio.terra.axonserver.model.ApiClusterStatus;
-import bio.terra.axonserver.model.ApiComponentUrlRequestBody;
 import bio.terra.axonserver.model.ApiNotebookStatus;
 import bio.terra.axonserver.model.ApiSignedUrlReport;
 import bio.terra.axonserver.model.ApiUrl;
@@ -18,7 +17,6 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
 import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -167,14 +165,13 @@ public class GcpResourceController extends ControllerBase implements GcpResource
    *
    * @param workspaceId Terra Workspace ID
    * @param resourceId Terra Resource ID
-   * @param body containing the componentKey to get the URL for
+   * @parm componentKey Dataproc optional component key
    * @return url to access component web UI
    */
   @Override
   public ResponseEntity<ApiUrl> getDataprocClusterComponentUrl(
-      UUID workspaceId, UUID resourceId, @Valid ApiComponentUrlRequestBody body) {
-    String componentUrl =
-        getCluster(workspaceId, resourceId).getComponentUrl(body.getComponentKey());
+      UUID workspaceId, UUID resourceId, String componentKey) {
+    String componentUrl = getCluster(workspaceId, resourceId).getComponentUrl(componentKey);
     return new ResponseEntity<>(new ApiUrl().url(componentUrl), HttpStatus.OK);
   }
 }

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -455,16 +455,15 @@ paths:
     parameters:
     - $ref: "#/components/parameters/WorkspaceId"
     - $ref: "#/components/parameters/ResourceId"
+    - in: query
+      name: componentKey
+      description: The component key to get a component proxy url.
+      schema:
+        type: string
     get:
       summary: Get a proxy url for an dataproc web UI component
       operationId: getDataprocClusterComponentUrl
       tags: [ GcpResource ]
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ComponentUrlRequestBody'
       responses:
         "200":
           $ref: '#/components/responses/ComponentUrlResponse'
@@ -739,7 +738,7 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
-          
+
 components:
   schemas:
     # Please keep alphabetized
@@ -761,13 +760,6 @@ components:
             - STOPPING
             - UNKNOWN
             - UPDATING
-
-    ComponentUrlRequestBody:
-      description: Request body for a dataproc cluster web UI component URL request.
-      required: [ componentKey ]
-      properties:
-        componentKey:
-          type: string
 
     ErrorReport:
       type: object

--- a/service/src/test/java/bio/terra/axonserver/app/controller/GcpResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/axonserver/app/controller/GcpResourceControllerTest.java
@@ -272,13 +272,12 @@ public class GcpResourceControllerTest extends BaseUnitTest {
     doReturn(cluster).when(gcpResourceController).getCluster(workspaceId, resourceId);
     when(cluster.getComponentUrl("fakekey")).thenReturn(fakeUrl);
 
-    String requestBody = "{\"componentKey\": \"fakekey\"}";
     String serializedGetResponse =
         mockMvc
             .perform(
                 get(operationPath)
                     .contentType("application/json")
-                    .content(requestBody)
+                    .param("componentKey", "fakekey")
                     .header("Authorization", String.format("bearer %s", fakeToken)))
             .andExpect(status().isOk())
             .andReturn()


### PR DESCRIPTION
The dataproc get cluster component url endpoint was incorrectly passing a request body. This change converts the request body into query params.