### PR TITLE
[PF-2929] Add get cluster metadata

### DIFF
--- a/service/src/main/java/bio/terra/axonserver/app/controller/AwsResourceController.java
+++ b/service/src/main/java/bio/terra/axonserver/app/controller/AwsResourceController.java
@@ -7,7 +7,7 @@ import bio.terra.axonserver.service.cloud.aws.AwsService;
 import bio.terra.axonserver.service.exception.FeatureNotEnabledException;
 import bio.terra.axonserver.service.features.FeatureService;
 import bio.terra.axonserver.service.wsm.WorkspaceManagerService;
-import bio.terra.axonserver.utils.notebook.AwsSageMakerNotebook;
+import bio.terra.axonserver.utils.notebook.AwsSageMakerNotebookUtil;
 import bio.terra.axonserver.utils.notebook.NotebookStatus;
 import bio.terra.common.exception.ForbiddenException;
 import bio.terra.common.exception.NotFoundException;
@@ -97,10 +97,10 @@ public class AwsResourceController extends ControllerBase implements AwsResource
 
   /** Do not use, public for spy testing */
   @VisibleForTesting
-  public AwsSageMakerNotebook getNotebook(UUID workspaceId, UUID resourceId) {
+  public AwsSageMakerNotebookUtil getNotebook(UUID workspaceId, UUID resourceId) {
     checkAwsEnabled();
     String accessToken = getAccessToken();
-    return AwsSageMakerNotebook.create(
+    return AwsSageMakerNotebookUtil.create(
         wsmService,
         wsmService.getResource(workspaceId, resourceId, accessToken),
         /*awsCredentialAccessScope=*/ null,
@@ -109,13 +109,13 @@ public class AwsResourceController extends ControllerBase implements AwsResource
 
   /** Do not use, public for spy testing */
   @VisibleForTesting
-  public AwsSageMakerNotebook getNotebook(
+  public AwsSageMakerNotebookUtil getNotebook(
       UUID workspaceId,
       UUID resourceId,
       @Nullable AwsCredentialAccessScope awsCredentialAccessScope) {
     checkAwsEnabled();
     String accessToken = getAccessToken();
-    return AwsSageMakerNotebook.create(
+    return AwsSageMakerNotebookUtil.create(
         wsmService,
         wsmService.getResource(workspaceId, resourceId, accessToken),
         awsCredentialAccessScope,

--- a/service/src/main/java/bio/terra/axonserver/app/controller/GcpResourceController.java
+++ b/service/src/main/java/bio/terra/axonserver/app/controller/GcpResourceController.java
@@ -28,7 +28,6 @@ import org.springframework.stereotype.Controller;
 
 @Controller
 public class GcpResourceController extends ControllerBase implements GcpResourceApi {
-
   private final WorkspaceManagerService wsmService;
   private final GcpService gcpService;
 

--- a/service/src/main/java/bio/terra/axonserver/app/controller/GcpResourceController.java
+++ b/service/src/main/java/bio/terra/axonserver/app/controller/GcpResourceController.java
@@ -210,14 +210,14 @@ public class GcpResourceController extends ControllerBase implements GcpResource
                 DataprocMetadataBuilderUtils.buildLifecycleConfig(
                     clusterConfig.getLifecycleConfig()));
 
-    Optional.ofNullable(clusterConfig.getAutoscalingConfig())
-        .ifPresent(config -> metadata.setAutoscalingPolicy(config.getPolicyUri()));
-
     Optional.ofNullable(clusterConfig.getInitializationActions())
         .ifPresent(
             actions ->
                 metadata.setInitializationActions(
                     actions.stream().map(NodeInitializationAction::getExecutableFile).toList()));
+
+    Optional.ofNullable(clusterConfig.getAutoscalingConfig())
+        .ifPresent(config -> metadata.setAutoscalingPolicy(config.getPolicyUri()));
 
     return new ResponseEntity<>(metadata, HttpStatus.OK);
   }

--- a/service/src/main/java/bio/terra/axonserver/app/controller/GcpResourceController.java
+++ b/service/src/main/java/bio/terra/axonserver/app/controller/GcpResourceController.java
@@ -10,8 +10,8 @@ import bio.terra.axonserver.service.cloud.gcp.GcpService;
 import bio.terra.axonserver.service.wsm.WorkspaceManagerService;
 import bio.terra.axonserver.utils.dataproc.ClusterStatus;
 import bio.terra.axonserver.utils.dataproc.DataprocMetadataBuilderUtils;
-import bio.terra.axonserver.utils.dataproc.GoogleDataprocCluster;
-import bio.terra.axonserver.utils.notebook.GoogleAIPlatformNotebook;
+import bio.terra.axonserver.utils.dataproc.GoogleDataprocClusterUtil;
+import bio.terra.axonserver.utils.notebook.GoogleAIPlatformNotebookUtil;
 import bio.terra.axonserver.utils.notebook.NotebookStatus;
 import bio.terra.common.iam.BearerTokenFactory;
 import com.google.api.services.dataproc.model.ClusterConfig;
@@ -44,9 +44,9 @@ public class GcpResourceController extends ControllerBase implements GcpResource
 
   /** Do not use, public for spy testing */
   @VisibleForTesting
-  public GoogleAIPlatformNotebook getNotebook(UUID workspaceId, UUID resourceId) {
+  public GoogleAIPlatformNotebookUtil getNotebook(UUID workspaceId, UUID resourceId) {
     GoogleCredentials credentials = gcpService.getPetSACredentials(workspaceId, getToken());
-    return GoogleAIPlatformNotebook.create(
+    return GoogleAIPlatformNotebookUtil.create(
         wsmService.getResource(workspaceId, resourceId, getAccessToken()), credentials);
   }
 
@@ -111,9 +111,9 @@ public class GcpResourceController extends ControllerBase implements GcpResource
 
   /** Do not use, public for spy testing */
   @VisibleForTesting
-  public GoogleDataprocCluster getCluster(UUID workspaceId, UUID resourceId) {
+  public GoogleDataprocClusterUtil getCluster(UUID workspaceId, UUID resourceId) {
     GoogleCredentials credentials = gcpService.getPetSACredentials(workspaceId, getToken());
-    return GoogleDataprocCluster.create(
+    return GoogleDataprocClusterUtil.create(
         wsmService.getResource(workspaceId, resourceId, getAccessToken()), credentials);
   }
 

--- a/service/src/main/java/bio/terra/axonserver/utils/dataproc/DataprocMetadataBuilderUtils.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/dataproc/DataprocMetadataBuilderUtils.java
@@ -1,0 +1,56 @@
+package bio.terra.axonserver.utils.dataproc;
+
+import bio.terra.axonserver.model.ApiClusterInstanceGroupConfig;
+import bio.terra.axonserver.model.ApiClusterLifecycleConfig;
+import com.google.api.services.dataproc.model.InstanceGroupConfig;
+import com.google.api.services.dataproc.model.LifecycleConfig;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+
+/** Utility class to build dataproc cluster metadata objects */
+public class DataprocMetadataBuilderUtils {
+  /**
+   * Utility method to build an api cluster instance group config from a dataproc cluster instance
+   * group config
+   */
+  public static ApiClusterInstanceGroupConfig buildInstanceGroupConfig(
+      InstanceGroupConfig instanceGroupConfig) {
+    return Optional.ofNullable(instanceGroupConfig)
+        .map(
+            config -> {
+              ApiClusterInstanceGroupConfig nodeGroupConfig =
+                  new ApiClusterInstanceGroupConfig()
+                      .numInstances(config.getNumInstances())
+                      .machineType(config.getMachineTypeUri());
+
+              Optional.ofNullable(config.getPreemptibility())
+                  .map(ApiClusterInstanceGroupConfig.PreemptibilityEnum::fromValue)
+                  .ifPresent(nodeGroupConfig::preemptibility);
+
+              return nodeGroupConfig;
+            })
+        .orElse(null);
+  }
+
+  // Utility method to build an api cluster lifecycle config from a dataproc cluster lifecycle
+  public static ApiClusterLifecycleConfig buildLifecycleConfig(LifecycleConfig lifecycleConfig) {
+    return Optional.ofNullable(lifecycleConfig)
+        .map(
+            config ->
+                new ApiClusterLifecycleConfig()
+                    .idleDeleteTtl(config.getIdleDeleteTtl())
+                    .idleStartTime(
+                        Optional.ofNullable(lifecycleConfig.getIdleStartTime())
+                            .map(Instant::parse)
+                            .map(Date::from)
+                            .orElse(null))
+                    .autoDeleteTtl(config.getAutoDeleteTtl())
+                    .autoDeleteTime(
+                        Optional.ofNullable(lifecycleConfig.getAutoDeleteTime())
+                            .map(Instant::parse)
+                            .map(Date::from)
+                            .orElse(null)))
+        .orElse(null);
+  }
+}

--- a/service/src/main/java/bio/terra/axonserver/utils/dataproc/DataprocMetadataBuilderUtils.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/dataproc/DataprocMetadataBuilderUtils.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 /** Utility class to build dataproc cluster metadata objects */
 public class DataprocMetadataBuilderUtils {
-   // Build an api cluster instance group config from a dataproc cluster instance group config
+  // Build an api cluster instance group config from a dataproc cluster instance group config
   public static ApiClusterInstanceGroupConfig buildInstanceGroupConfig(
       InstanceGroupConfig instanceGroupConfig) {
     return Optional.ofNullable(instanceGroupConfig)

--- a/service/src/main/java/bio/terra/axonserver/utils/dataproc/DataprocMetadataBuilderUtils.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/dataproc/DataprocMetadataBuilderUtils.java
@@ -10,10 +10,7 @@ import java.util.Optional;
 
 /** Utility class to build dataproc cluster metadata objects */
 public class DataprocMetadataBuilderUtils {
-  /**
-   * Utility method to build an api cluster instance group config from a dataproc cluster instance
-   * group config
-   */
+   // Build an api cluster instance group config from a dataproc cluster instance group config
   public static ApiClusterInstanceGroupConfig buildInstanceGroupConfig(
       InstanceGroupConfig instanceGroupConfig) {
     return Optional.ofNullable(instanceGroupConfig)
@@ -33,7 +30,7 @@ public class DataprocMetadataBuilderUtils {
         .orElse(null);
   }
 
-  // Utility method to build an api cluster lifecycle config from a dataproc cluster lifecycle
+  // Build an api cluster lifecycle config from a dataproc cluster lifecycle config
   public static ApiClusterLifecycleConfig buildLifecycleConfig(LifecycleConfig lifecycleConfig) {
     return Optional.ofNullable(lifecycleConfig)
         .map(

--- a/service/src/main/java/bio/terra/axonserver/utils/dataproc/GoogleDataprocCluster.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/dataproc/GoogleDataprocCluster.java
@@ -158,7 +158,7 @@ public class GoogleDataprocCluster {
   /**
    * Gets cluster config properties.
    *
-   * @return the cluster
+   * @return the cluster config
    */
   public ClusterConfig getClusterConfig() {
     return get("get cluster metadata").getConfig();

--- a/service/src/main/java/bio/terra/axonserver/utils/dataproc/GoogleDataprocCluster.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/dataproc/GoogleDataprocCluster.java
@@ -11,6 +11,7 @@ import bio.terra.workspace.model.GcpDataprocClusterAttributes;
 import bio.terra.workspace.model.ResourceDescription;
 import bio.terra.workspace.model.ResourceType;
 import com.google.api.services.dataproc.model.Cluster;
+import com.google.api.services.dataproc.model.ClusterConfig;
 import com.google.api.services.dataproc.model.Operation;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.annotations.VisibleForTesting;
@@ -124,14 +125,6 @@ public class GoogleDataprocCluster {
     }
   }
 
-  private Cluster get(String operation) {
-    try {
-      return dataprocCow.clusters().get(clusterName).execute();
-    } catch (IOException e) {
-      throw new InternalServerErrorException(getOperationErrorMessage(operation), e);
-    }
-  }
-
   /**
    * Gets current status of the Dataproc cluster.
    *
@@ -160,5 +153,22 @@ public class GoogleDataprocCluster {
               componentKey));
     }
     return componentUrl;
+  }
+
+  /**
+   * Gets cluster config properties.
+   *
+   * @return the cluster
+   */
+  public ClusterConfig getClusterConfig() {
+    return get("get cluster metadata").getConfig();
+  }
+
+  private Cluster get(String operation) {
+    try {
+      return dataprocCow.clusters().get(clusterName).execute();
+    } catch (IOException e) {
+      throw new InternalServerErrorException(getOperationErrorMessage(operation), e);
+    }
   }
 }

--- a/service/src/main/java/bio/terra/axonserver/utils/dataproc/GoogleDataprocClusterUtil.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/dataproc/GoogleDataprocClusterUtil.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 import javax.ws.rs.InternalServerErrorException;
 
 /** Utility class for running common dataproc cluster operations on a Google Dataproc cluster. */
-public class GoogleDataprocCluster {
+public class GoogleDataprocClusterUtil {
 
   private static final ClientConfig clientConfig =
       ClientConfig.Builder.newBuilder().setClient("terra-axon-server").build();
@@ -30,7 +30,7 @@ public class GoogleDataprocCluster {
 
   /** For testing use only, allows use of mock {@link DataprocCow}. */
   @VisibleForTesting
-  public GoogleDataprocCluster(ClusterName clusterName, DataprocCow dataprocCow) {
+  public GoogleDataprocClusterUtil(ClusterName clusterName, DataprocCow dataprocCow) {
     this.clusterName = clusterName;
     this.dataprocCow = dataprocCow;
   }
@@ -43,20 +43,20 @@ public class GoogleDataprocCluster {
         .build();
   }
 
-  private GoogleDataprocCluster(ResourceDescription resource, GoogleCredentials credentials)
+  private GoogleDataprocClusterUtil(ResourceDescription resource, GoogleCredentials credentials)
       throws GeneralSecurityException, IOException {
     this(
         buildClusterName(resource.getResourceAttributes().getGcpDataprocCluster()),
         DataprocCow.create(clientConfig, credentials));
   }
 
-  /** Factory method to create an instance of class {@link GoogleDataprocCluster}. */
-  public static GoogleDataprocCluster create(
+  /** Factory method to create an instance of class {@link GoogleDataprocClusterUtil}. */
+  public static GoogleDataprocClusterUtil create(
       ResourceDescription resourceDescription, GoogleCredentials credentials) {
     ResourceUtils.validateResourceType(ResourceType.DATAPROC_CLUSTER, resourceDescription);
 
     try {
-      return new GoogleDataprocCluster(resourceDescription, credentials);
+      return new GoogleDataprocClusterUtil(resourceDescription, credentials);
     } catch (GeneralSecurityException | IOException e) {
       throw new InternalServerErrorException(e);
     }

--- a/service/src/main/java/bio/terra/axonserver/utils/notebook/AwsSageMakerNotebookUtil.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/notebook/AwsSageMakerNotebookUtil.java
@@ -18,7 +18,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.sagemaker.model.NotebookInstanceStatus;
 
 /** Utility class for running common notebook operations on an AWS SageMaker Notebook instance. */
-public class AwsSageMakerNotebook {
+public class AwsSageMakerNotebookUtil {
   private static final ClientConfig clientConfig =
       ClientConfig.Builder.newBuilder().setClient("terra-axon-server").build();
 
@@ -56,12 +56,12 @@ public class AwsSageMakerNotebook {
 
   /** For testing use only, allows use of mock {@link SageMakerNotebookCow}. */
   @VisibleForTesting
-  public AwsSageMakerNotebook(String instanceName, SageMakerNotebookCow sageMakerNotebookCow) {
+  public AwsSageMakerNotebookUtil(String instanceName, SageMakerNotebookCow sageMakerNotebookCow) {
     this.instanceName = instanceName;
     this.sageMakerNotebookCow = sageMakerNotebookCow;
   }
 
-  private AwsSageMakerNotebook(
+  private AwsSageMakerNotebookUtil(
       WorkspaceManagerService workspaceManagerService,
       ResourceDescription resource,
       AwsCredentialAccessScope awsCredentialAccessScope,
@@ -75,14 +75,14 @@ public class AwsSageMakerNotebook {
             resource.getMetadata().getControlledResourceMetadata().getRegion()));
   }
 
-  /** Factory method to create an instance of class {@link AwsSageMakerNotebook}. */
-  public static AwsSageMakerNotebook create(
+  /** Factory method to create an instance of class {@link AwsSageMakerNotebookUtil}. */
+  public static AwsSageMakerNotebookUtil create(
       WorkspaceManagerService workspaceManagerService,
       ResourceDescription resourceDescription,
       AwsCredentialAccessScope awsCredentialAccessScope,
       String accessToken) {
     ResourceUtils.validateResourceType(ResourceType.AWS_SAGEMAKER_NOTEBOOK, resourceDescription);
-    return new AwsSageMakerNotebook(
+    return new AwsSageMakerNotebookUtil(
         workspaceManagerService, resourceDescription, awsCredentialAccessScope, accessToken);
   }
 

--- a/service/src/main/java/bio/terra/axonserver/utils/notebook/GoogleAIPlatformNotebookUtil.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/notebook/GoogleAIPlatformNotebookUtil.java
@@ -19,7 +19,7 @@ import java.time.Duration;
 import javax.ws.rs.InternalServerErrorException;
 
 /** Utility class for running common notebook operations on a Google Vertex AI Notebook instance. */
-public class GoogleAIPlatformNotebook {
+public class GoogleAIPlatformNotebookUtil {
 
   private static final ClientConfig clientConfig =
       ClientConfig.Builder.newBuilder().setClient("terra-axon-server").build();
@@ -28,7 +28,7 @@ public class GoogleAIPlatformNotebook {
 
   /** For testing use only, allows use of mock {@link AIPlatformNotebooksCow}. */
   @VisibleForTesting
-  public GoogleAIPlatformNotebook(
+  public GoogleAIPlatformNotebookUtil(
       InstanceName instanceName, AIPlatformNotebooksCow aiPlatformNotebooksCow) {
     this.instanceName = instanceName;
     this.aiPlatformNotebooksCow = aiPlatformNotebooksCow;
@@ -42,20 +42,20 @@ public class GoogleAIPlatformNotebook {
         .build();
   }
 
-  private GoogleAIPlatformNotebook(ResourceDescription resource, GoogleCredentials credentials)
+  private GoogleAIPlatformNotebookUtil(ResourceDescription resource, GoogleCredentials credentials)
       throws GeneralSecurityException, IOException {
     this(
         buildInstanceName(resource.getResourceAttributes().getGcpAiNotebookInstance()),
         AIPlatformNotebooksCow.create(clientConfig, credentials));
   }
 
-  /** Factory method to create an instance of class {@link GoogleAIPlatformNotebook}. */
-  public static GoogleAIPlatformNotebook create(
+  /** Factory method to create an instance of class {@link GoogleAIPlatformNotebookUtil}. */
+  public static GoogleAIPlatformNotebookUtil create(
       ResourceDescription resourceDescription, GoogleCredentials credentials) {
     ResourceUtils.validateResourceType(ResourceType.AI_NOTEBOOK, resourceDescription);
 
     try {
-      return new GoogleAIPlatformNotebook(resourceDescription, credentials);
+      return new GoogleAIPlatformNotebookUtil(resourceDescription, credentials);
     } catch (GeneralSecurityException | IOException e) {
       throw new InternalServerErrorException(e);
     }

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -873,18 +873,6 @@ components:
           items:
             type: string
 
-    NodeGroupConfig:
-      description: Configuration for a group of dataproc cluster nodes.
-      type: object
-      properties:
-        machineType:
-          type: string
-        numInstances:
-          type: integer
-        preemptibility:
-          type: string
-          enum: [ "NON_PREEMPTIBLE", "PREEMPTIBLE", "SPOT" ]
-
     NotebookStatus:
       type: object
       required: [ notebookStatus ]

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -398,8 +398,6 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/ServerError"
-        "501":
-          $ref: "#/components/responses/NotImplemented"
 
   /api/workspaces/v1/{workspaceId}/resources/{resourceId}/gcp/dataproccluster/stop:
     parameters:
@@ -426,8 +424,6 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/ServerError"
-        "501":
-          $ref: "#/components/responses/NotImplemented"
 
   /api/workspaces/v1/{workspaceId}/resources/{resourceId}/gcp/dataproccluster/status:
     parameters:
@@ -448,8 +444,6 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/ServerError"
-        "501":
-          $ref: "#/components/responses/NotImplemented"
 
   /api/workspaces/v1/{workspaceId}/resources/{resourceId}/gcp/dataproccluster/componentUrl:
     parameters:
@@ -475,8 +469,26 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/ServerError"
-        "501":
-          $ref: "#/components/responses/NotImplemented"
+
+  /api/workspaces/v1/{workspaceId}/resources/{resourceId}/gcp/dataproccluster/metadata:
+    parameters:
+    - $ref: "#/components/parameters/WorkspaceId"
+    - $ref: "#/components/parameters/ResourceId"
+    get:
+      summary: Get cluster metadata of a GCP Dataproc cluster
+      operationId: getDataprocClusterMetadata
+      tags: [ GcpResource ]
+      responses:
+        "200":
+          $ref: '#/components/responses/ClusterMetadataResponse'
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/PermissionDenied"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/ServerError"
 
   # Cromwell paths.
   /api/workspaces/{workspaceId}/cromwell/workflows/{workflowId}/status:
@@ -742,6 +754,93 @@ paths:
 components:
   schemas:
     # Please keep alphabetized
+    ClusterMetadata:
+      type: object
+      required:
+      - configBucket
+      - tempBucket
+      - managerNodeConfig
+      - primaryWorkerConfig
+      properties:
+        initializationActions:
+          type: array
+          items:
+            type: string
+          description: Initialization actions for the cluster.
+        configBucket:
+          type: string
+          description: The config bucket name used by the cluster
+        tempBucket:
+          type: string
+          description: The temp bucket name used by the cluster
+        autoscalingPolicy:
+          type: string
+          description: URI of autoscaling policy.
+        metadata:
+          type: object
+          description: Metadata key-value pairs.
+          additionalProperties:
+            type: string
+        managerNodeConfig:
+          $ref: '#/components/schemas/ClusterInstanceGroupConfig'
+        primaryWorkerConfig:
+          $ref: '#/components/schemas/ClusterInstanceGroupConfig'
+        secondaryWorkerConfig:
+          $ref: '#/components/schemas/ClusterInstanceGroupConfig'
+        lifecycleConfig:
+          $ref: '#/components/schemas/ClusterLifecycleConfig'
+
+    ClusterInstanceGroupConfig:
+      type: object
+      required:
+      - numInstances
+      - machineType
+      properties:
+        numInstances:
+          type: integer
+          format: int32
+          description: Number of instances in the instance group.
+        machineType:
+          type: string
+          description: Compute engine machine type.
+        imageUri:
+          type: string
+          description: Compute engine image used for cluster instances.
+        bootDiskSizeGb:
+          type: integer
+          format: int32
+          default: 500
+          description: The size of the boot disk in GB.
+        preemptibility:
+          type: string
+          enum: [ "NON_PREEMPTIBLE", "PREEMPTIBLE", "SPOT" ]
+          description: Instance preemption behavior.
+
+    ClusterLifecycleConfig:
+      description: >-
+        The lifecycle options for a cluster.
+        See https://cloud.google.com/dataproc/docs/reference/rest/v1/ClusterConfig#LifecycleConfig
+      type: object
+      properties:
+        idleDeleteTtl:
+          type: string
+          description: Duration of idling before cluster is deleted. See https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/scheduled-deletion.
+          example: 1800s
+        idleStartTime:
+          type: string
+          format: date-time
+          description: Time when cluster became idle.
+          example: 2014-10-02T15:01:23.045123456Z
+        autoDeleteTime:
+          type: string
+          format: date-time
+          description: Date of cluster deletion in UTC "Zulu" format. Must not be specified if autoDeleteTtl is specified.
+          example: 2014-10-02T15:01:23.045123456Z
+        autoDeleteTtl:
+          type: string
+          description: Duration of cluster life in seconds. Must not be specified if autoDeleteTime is specified.
+          example: 3.5s
+
     ClusterStatus:
       type: object
       required: [ status ]
@@ -773,6 +872,18 @@ components:
           type: array
           items:
             type: string
+
+    NodeGroupConfig:
+      description: Configuration for a group of dataproc cluster nodes.
+      type: object
+      properties:
+        machineType:
+          type: string
+        numInstances:
+          type: integer
+        preemptibility:
+          type: string
+          enum: [ "NON_PREEMPTIBLE", "PREEMPTIBLE", "SPOT" ]
 
     NotebookStatus:
       type: object
@@ -1127,6 +1238,13 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorReport"
+
+    ClusterMetadataResponse:
+      description: Dataproc cluster metadata.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ClusterMetadata'
 
     ClusterStatusResponse:
       description: Dataproc cluster status.

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -834,11 +834,11 @@ components:
         autoDeleteTime:
           type: string
           format: date-time
-          description: Date of cluster deletion in UTC "Zulu" format. Must not be specified if autoDeleteTtl is specified.
+          description: Date of cluster deletion in UTC "Zulu" format.
           example: 2014-10-02T15:01:23.045123456Z
         autoDeleteTtl:
           type: string
-          description: Duration of cluster life in seconds. Must not be specified if autoDeleteTime is specified.
+          description: Duration of cluster life in seconds.
           example: 3.5s
 
     ClusterStatus:

--- a/service/src/test/java/bio/terra/axonserver/app/controller/AwsResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/axonserver/app/controller/AwsResourceControllerTest.java
@@ -22,7 +22,7 @@ import bio.terra.axonserver.service.cloud.aws.AwsService;
 import bio.terra.axonserver.service.exception.InvalidResourceTypeException;
 import bio.terra.axonserver.service.wsm.WorkspaceManagerService;
 import bio.terra.axonserver.testutils.BaseUnitTest;
-import bio.terra.axonserver.utils.notebook.AwsSageMakerNotebook;
+import bio.terra.axonserver.utils.notebook.AwsSageMakerNotebookUtil;
 import bio.terra.axonserver.utils.notebook.NotebookStatus;
 import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.common.exception.NotFoundException;
@@ -226,7 +226,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
   void notebookStart() throws Exception {
     String operationPath = getNotebookOperationPath("start");
 
-    AwsSageMakerNotebook notebook = mock(AwsSageMakerNotebook.class);
+    AwsSageMakerNotebookUtil notebook = mock(AwsSageMakerNotebookUtil.class);
     doReturn(notebook).when(awsResourceController).getNotebook(workspaceId, resourceId);
     doNothing().when(notebook).start(anyBoolean());
     mockMvc
@@ -242,7 +242,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
   void notebookStart_wait() throws Exception {
     String operationPath = getNotebookOperationPath("start");
 
-    AwsSageMakerNotebook notebook = mock(AwsSageMakerNotebook.class);
+    AwsSageMakerNotebookUtil notebook = mock(AwsSageMakerNotebookUtil.class);
     doReturn(notebook).when(awsResourceController).getNotebook(workspaceId, resourceId);
     doNothing().when(notebook).start(anyBoolean());
     mockMvc
@@ -261,7 +261,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
   void notebookStop() throws Exception {
     String operationPath = getNotebookOperationPath("stop");
 
-    AwsSageMakerNotebook notebook = mock(AwsSageMakerNotebook.class);
+    AwsSageMakerNotebookUtil notebook = mock(AwsSageMakerNotebookUtil.class);
     doReturn(notebook).when(awsResourceController).getNotebook(workspaceId, resourceId);
     doNothing().when(notebook).stop(anyBoolean());
     mockMvc
@@ -277,7 +277,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
   void notebookStop_wait() throws Exception {
     String operationPath = getNotebookOperationPath("stop");
 
-    AwsSageMakerNotebook notebook = mock(AwsSageMakerNotebook.class);
+    AwsSageMakerNotebookUtil notebook = mock(AwsSageMakerNotebookUtil.class);
     doReturn(notebook).when(awsResourceController).getNotebook(workspaceId, resourceId);
     doNothing().when(notebook).stop(anyBoolean());
     mockMvc
@@ -296,7 +296,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
   void notebookStatus() throws Exception {
     String operationPath = getNotebookOperationPath("status");
 
-    AwsSageMakerNotebook notebook = mock(AwsSageMakerNotebook.class);
+    AwsSageMakerNotebookUtil notebook = mock(AwsSageMakerNotebookUtil.class);
     doReturn(notebook)
         .when(awsResourceController)
         .getNotebook(workspaceId, resourceId, AwsCredentialAccessScope.READ_ONLY);
@@ -323,7 +323,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
     String operationPath = getNotebookOperationPath("proxyUrl");
 
     String fakeUrl = "https://example.com";
-    AwsSageMakerNotebook notebook = mock(AwsSageMakerNotebook.class);
+    AwsSageMakerNotebookUtil notebook = mock(AwsSageMakerNotebookUtil.class);
     doReturn(notebook).when(awsResourceController).getNotebook(workspaceId, resourceId);
     when(notebook.getProxyUrl()).thenReturn(fakeUrl);
 

--- a/service/src/test/java/bio/terra/axonserver/app/controller/GcpResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/axonserver/app/controller/GcpResourceControllerTest.java
@@ -22,8 +22,8 @@ import bio.terra.axonserver.model.ApiUrl;
 import bio.terra.axonserver.testutils.BaseUnitTest;
 import bio.terra.axonserver.testutils.MockMvcUtils;
 import bio.terra.axonserver.utils.dataproc.ClusterStatus;
-import bio.terra.axonserver.utils.dataproc.GoogleDataprocCluster;
-import bio.terra.axonserver.utils.notebook.GoogleAIPlatformNotebook;
+import bio.terra.axonserver.utils.dataproc.GoogleDataprocClusterUtil;
+import bio.terra.axonserver.utils.notebook.GoogleAIPlatformNotebookUtil;
 import bio.terra.axonserver.utils.notebook.NotebookStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.services.dataproc.model.Cluster;
@@ -73,7 +73,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
   void notebookStart() throws Exception {
     String operationPath = getNotebookOperationPath("start");
 
-    GoogleAIPlatformNotebook notebook = mock(GoogleAIPlatformNotebook.class);
+    GoogleAIPlatformNotebookUtil notebook = mock(GoogleAIPlatformNotebookUtil.class);
     doReturn(notebook).when(gcpResourceController).getNotebook(workspaceId, resourceId);
     doNothing().when(notebook).start(anyBoolean());
     mockMvc
@@ -89,7 +89,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
   void notebookStart_wait() throws Exception {
     String operationPath = getNotebookOperationPath("start");
 
-    GoogleAIPlatformNotebook notebook = mock(GoogleAIPlatformNotebook.class);
+    GoogleAIPlatformNotebookUtil notebook = mock(GoogleAIPlatformNotebookUtil.class);
     doReturn(notebook).when(gcpResourceController).getNotebook(workspaceId, resourceId);
     doNothing().when(notebook).start(anyBoolean());
     mockMvc
@@ -108,7 +108,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
   void notebookStop() throws Exception {
     String operationPath = getNotebookOperationPath("stop");
 
-    GoogleAIPlatformNotebook notebook = mock(GoogleAIPlatformNotebook.class);
+    GoogleAIPlatformNotebookUtil notebook = mock(GoogleAIPlatformNotebookUtil.class);
     doReturn(notebook).when(gcpResourceController).getNotebook(workspaceId, resourceId);
     doNothing().when(notebook).stop(anyBoolean());
     mockMvc
@@ -124,7 +124,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
   void notebookStop_wait() throws Exception {
     String operationPath = getNotebookOperationPath("stop");
 
-    GoogleAIPlatformNotebook notebook = mock(GoogleAIPlatformNotebook.class);
+    GoogleAIPlatformNotebookUtil notebook = mock(GoogleAIPlatformNotebookUtil.class);
     doReturn(notebook).when(gcpResourceController).getNotebook(workspaceId, resourceId);
     doNothing().when(notebook).stop(anyBoolean());
     mockMvc
@@ -140,7 +140,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
   void notebookStatus() throws Exception {
     String operationPath = getNotebookOperationPath("status");
 
-    GoogleAIPlatformNotebook notebook = mock(GoogleAIPlatformNotebook.class);
+    GoogleAIPlatformNotebookUtil notebook = mock(GoogleAIPlatformNotebookUtil.class);
     doReturn(notebook).when(gcpResourceController).getNotebook(workspaceId, resourceId);
     when(notebook.getStatus()).thenReturn(NotebookStatus.ACTIVE);
 
@@ -164,7 +164,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
     String operationPath = getNotebookOperationPath("proxyUrl");
 
     String fakeUrl = "https://example.com";
-    GoogleAIPlatformNotebook notebook = mock(GoogleAIPlatformNotebook.class);
+    GoogleAIPlatformNotebookUtil notebook = mock(GoogleAIPlatformNotebookUtil.class);
     doReturn(notebook).when(gcpResourceController).getNotebook(workspaceId, resourceId);
     when(notebook.getProxyUrl()).thenReturn(fakeUrl);
 
@@ -182,7 +182,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
   void clusterStart() throws Exception {
     String operationPath = getClusterOperationPath("start");
 
-    GoogleDataprocCluster cluster = mock(GoogleDataprocCluster.class);
+    GoogleDataprocClusterUtil cluster = mock(GoogleDataprocClusterUtil.class);
     doReturn(cluster).when(gcpResourceController).getCluster(workspaceId, resourceId);
     doNothing().when(cluster).start(anyBoolean());
     mockMvc.perform(addAuth(put(operationPath), USER_REQUEST)).andExpect(status().isOk());
@@ -196,7 +196,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
   void clusterStart_wait() throws Exception {
     String operationPath = getClusterOperationPath("start");
 
-    GoogleDataprocCluster cluster = mock(GoogleDataprocCluster.class);
+    GoogleDataprocClusterUtil cluster = mock(GoogleDataprocClusterUtil.class);
     doReturn(cluster).when(gcpResourceController).getCluster(workspaceId, resourceId);
     doNothing().when(cluster).start(anyBoolean());
     mockMvc
@@ -212,7 +212,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
   void clusterStop() throws Exception {
     String operationPath = getClusterOperationPath("stop");
 
-    GoogleDataprocCluster cluster = mock(GoogleDataprocCluster.class);
+    GoogleDataprocClusterUtil cluster = mock(GoogleDataprocClusterUtil.class);
     doReturn(cluster).when(gcpResourceController).getCluster(workspaceId, resourceId);
     doNothing().when(cluster).stop(anyBoolean());
     mockMvc.perform(addAuth(put(operationPath), USER_REQUEST)).andExpect(status().isOk());
@@ -226,7 +226,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
   void clusterStop_wait() throws Exception {
     String operationPath = getClusterOperationPath("stop");
 
-    GoogleDataprocCluster cluster = mock(GoogleDataprocCluster.class);
+    GoogleDataprocClusterUtil cluster = mock(GoogleDataprocClusterUtil.class);
     doReturn(cluster).when(gcpResourceController).getCluster(workspaceId, resourceId);
     doNothing().when(cluster).stop(anyBoolean());
     mockMvc
@@ -242,7 +242,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
   void clusterStatus() throws Exception {
     String operationPath = getClusterOperationPath("status");
 
-    GoogleDataprocCluster cluster = mock(GoogleDataprocCluster.class);
+    GoogleDataprocClusterUtil cluster = mock(GoogleDataprocClusterUtil.class);
     doReturn(cluster).when(gcpResourceController).getCluster(workspaceId, resourceId);
     when(cluster.getStatus()).thenReturn(ClusterStatus.RUNNING);
 
@@ -260,7 +260,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
     String operationPath = getClusterOperationPath("componentUrl");
 
     String fakeUrl = "https://example.com";
-    GoogleDataprocCluster cluster = mock(GoogleDataprocCluster.class);
+    GoogleDataprocClusterUtil cluster = mock(GoogleDataprocClusterUtil.class);
     doReturn(cluster).when(gcpResourceController).getCluster(workspaceId, resourceId);
     when(cluster.getComponentUrl("fakekey")).thenReturn(fakeUrl);
 
@@ -284,12 +284,15 @@ public class GcpResourceControllerTest extends BaseUnitTest {
   void clusterMetadata_get() throws Exception {
     String operationPath = getClusterOperationPath("metadata");
 
-    GoogleDataprocCluster mockGoogleDataprocCluster = mock(GoogleDataprocCluster.class);
+    GoogleDataprocClusterUtil mockGoogleDataprocCluster = mock(GoogleDataprocClusterUtil.class);
     Cluster mockCluster = mock(Cluster.class, finalMockSettings);
     ClusterConfig mockClusterConfig = mock(ClusterConfig.class, finalMockSettings);
     GceClusterConfig mockGceClusterConfig = mock(GceClusterConfig.class, finalMockSettings);
     InstanceGroupConfig mockMasterConfig = mock(InstanceGroupConfig.class, finalMockSettings);
     InstanceGroupConfig mockWorkerConfig = mock(InstanceGroupConfig.class, finalMockSettings);
+
+    int numManagerNodes = 1;
+    int numWorkerNodes = 2;
 
     doReturn(mockGoogleDataprocCluster)
         .when(gcpResourceController)
@@ -300,17 +303,17 @@ public class GcpResourceControllerTest extends BaseUnitTest {
     when(mockClusterConfig.getMasterConfig()).thenReturn(mockMasterConfig);
     when(mockClusterConfig.getWorkerConfig()).thenReturn(mockWorkerConfig);
     when(mockClusterConfig.getSecondaryWorkerConfig()).thenReturn(mockWorkerConfig);
-    when(mockMasterConfig.getNumInstances()).thenReturn(1);
-    when(mockWorkerConfig.getNumInstances()).thenReturn(2);
+    when(mockMasterConfig.getNumInstances()).thenReturn(numManagerNodes);
+    when(mockWorkerConfig.getNumInstances()).thenReturn(numWorkerNodes);
 
     String serializedGetResponse =
         mockMvcUtils.getSerializedResponseForGet(USER_REQUEST, operationPath);
 
     ApiClusterMetadata metadata =
         objectMapper.readValue(serializedGetResponse, ApiClusterMetadata.class);
-    assertEquals(1, metadata.getManagerNodeConfig().getNumInstances());
-    assertEquals(2, metadata.getPrimaryWorkerConfig().getNumInstances());
-    assertEquals(2, metadata.getSecondaryWorkerConfig().getNumInstances());
+    assertEquals(numManagerNodes, metadata.getManagerNodeConfig().getNumInstances());
+    assertEquals(numWorkerNodes, metadata.getPrimaryWorkerConfig().getNumInstances());
+    assertEquals(numWorkerNodes, metadata.getSecondaryWorkerConfig().getNumInstances());
     Mockito.verify(mockGoogleDataprocCluster).getClusterConfig();
   }
 }

--- a/service/src/test/java/bio/terra/axonserver/testutils/MockMvcUtils.java
+++ b/service/src/test/java/bio/terra/axonserver/testutils/MockMvcUtils.java
@@ -30,7 +30,7 @@ public class MockMvcUtils {
   public String getSerializedResponseForGet(BearerToken userRequest, String formattedPath)
       throws Exception {
     return mockMvc
-        .perform(addAuth(get(formattedPath), userRequest))
+        .perform(addJsonContentType(addAuth(get(formattedPath), userRequest)))
         .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
         .andReturn()
         .getResponse()
@@ -41,13 +41,14 @@ public class MockMvcUtils {
       BearerToken userRequest, String formattedPath, String request) throws Exception {
     return mockMvc
         .perform(
-            addAuth(
-                post(formattedPath)
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .characterEncoding("UTF-8")
-                    .content(request),
-                userRequest))
+            addJsonContentType(
+                addAuth(
+                    post(formattedPath)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8")
+                        .content(request),
+                    userRequest)))
         .andExpect(MockMvcResultMatchers.status().is2xxSuccessful())
         .andReturn()
         .getResponse()

--- a/service/src/test/java/bio/terra/axonserver/utils/dataproc/GoogleDataprocClusterTest.java
+++ b/service/src/test/java/bio/terra/axonserver/utils/dataproc/GoogleDataprocClusterTest.java
@@ -48,10 +48,10 @@ public class GoogleDataprocClusterTest {
 
   /**
    * Test cluster is wrapped in a Mockito spy so that we can stub/verify calls to {@link
-   * GoogleDataprocCluster#pollForSuccess}.
+   * GoogleDataprocClusterUtil#pollForSuccess}.
    */
-  private final GoogleDataprocCluster cluster =
-      spy(new GoogleDataprocCluster(clusterName, dataprocCow));
+  private final GoogleDataprocClusterUtil cluster =
+      spy(new GoogleDataprocClusterUtil(clusterName, dataprocCow));
 
   private final DataprocCow.Clusters mockClusters = mock(DataprocCow.Clusters.class);
   private final Operation mockOperation = mock(Operation.class, finalMockSettings);

--- a/service/src/test/java/bio/terra/axonserver/utils/notebook/AwsSageMakerNotebookTest.java
+++ b/service/src/test/java/bio/terra/axonserver/utils/notebook/AwsSageMakerNotebookTest.java
@@ -16,8 +16,8 @@ public class AwsSageMakerNotebookTest {
   private final String instanceName = "fakeinstancename";
   private final SageMakerNotebookCow sageMakerNotebookCow = mock(SageMakerNotebookCow.class);
 
-  private final AwsSageMakerNotebook notebook =
-      new AwsSageMakerNotebook(instanceName, sageMakerNotebookCow);
+  private final AwsSageMakerNotebookUtil notebook =
+      new AwsSageMakerNotebookUtil(instanceName, sageMakerNotebookCow);
 
   @AfterEach
   public void tearDown() {

--- a/service/src/test/java/bio/terra/axonserver/utils/notebook/GoogleAIPlatformNotebookTest.java
+++ b/service/src/test/java/bio/terra/axonserver/utils/notebook/GoogleAIPlatformNotebookTest.java
@@ -42,10 +42,10 @@ public class GoogleAIPlatformNotebookTest {
 
   /**
    * Test notebook instance is wrapped in a Mockito spy so that we can stub/verify calls to {@link
-   * GoogleAIPlatformNotebook#pollForSuccess}.
+   * GoogleAIPlatformNotebookUtil#pollForSuccess}.
    */
-  private final GoogleAIPlatformNotebook notebook =
-      spy(new GoogleAIPlatformNotebook(instanceName, aiPlatformNotebooksCow));
+  private final GoogleAIPlatformNotebookUtil notebook =
+      spy(new GoogleAIPlatformNotebookUtil(instanceName, aiPlatformNotebooksCow));
 
   private final AIPlatformNotebooksCow.Instances mockInstances =
       mock(AIPlatformNotebooksCow.Instances.class);


### PR DESCRIPTION
Adds an endpoint to fetch cluster metadata for the UI to render on the environment card and edit dialog. These properties aren't managed by WSM so ideally we retrieve them from axonserver rather than directly from gcp.