### PR TITLE
[PF-2929] Add zoneUri to get cluster metadata

### DIFF
--- a/service/src/main/java/bio/terra/axonserver/app/controller/GcpResourceController.java
+++ b/service/src/main/java/bio/terra/axonserver/app/controller/GcpResourceController.java
@@ -197,6 +197,7 @@ public class GcpResourceController extends ControllerBase implements GcpResource
             .configBucket(clusterConfig.getConfigBucket())
             .tempBucket(clusterConfig.getTempBucket())
             .metadata(clusterConfig.getGceClusterConfig().getMetadata())
+            .zoneUri(clusterConfig.getGceClusterConfig().getZoneUri())
             .managerNodeConfig(
                 DataprocMetadataBuilderUtils.buildInstanceGroupConfig(
                     clusterConfig.getMasterConfig()))

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -781,6 +781,9 @@ components:
           description: Metadata key-value pairs.
           additionalProperties:
             type: string
+        zoneUri:
+          type: string
+          description: URI of the zone where the cluster's gce instance nodes are located.
         managerNodeConfig:
           $ref: '#/components/schemas/ClusterInstanceGroupConfig'
         primaryWorkerConfig:


### PR DESCRIPTION
The UI needs to query the guest attributes of the underlying gce instance in clusters to determine the startup script completion status. This change exposes the cluster's autozone attribute so the UI can directly query the guest attributes on the manager node gce instance.