### PR TITLE
Switch puts to posts for start/stop endpoints

### DIFF
--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -182,7 +182,9 @@ paths:
         schema:
           type: boolean
           default: false
-    put:
+    # Using POST instead of PUT since jersey2 doesn't support PUT without body
+    # TODO: PF-2593 - Change to PUT if we override with moustache templating
+    post:
       summary: Starts an AWS SageMaker Notebook Instance
       operationId: putSageMakerNotebookStart
       tags: [ AwsResource ]
@@ -210,7 +212,9 @@ paths:
         schema:
           type: boolean
           default: false
-    put:
+    # Using POST instead of PUT since jersey2 doesn't support PUT without body
+    # TODO: PF-2593 - Change to PUT if we override with moustache templating
+    post:
       summary: Stop an AWS SageMaker Notebook Instance
       operationId: putSageMakerNotebookStop
       tags: [ AwsResource ]
@@ -283,7 +287,9 @@ paths:
         schema:
           type: boolean
           default: false
-    put:
+    # Using POST instead of PUT since jersey2 doesn't support PUT without body
+    # TODO: PF-2593 - Change to PUT if we override with moustache templating
+    post:
       summary: Starts a GCP Vertex AI Notebook Instance
       operationId: putAiNotebookStart
       tags: [ GcpResource ]
@@ -311,7 +317,9 @@ paths:
         schema:
           type: boolean
           default: false
-    put:
+    # Using POST instead of PUT since jersey2 doesn't support PUT without body
+    # TODO: PF-2593 - Change to PUT if we override with moustache templating
+    post:
       summary: Stop a GCP Vertex AI Notebook Instance
       operationId: putAiNotebookStop
       tags: [ GcpResource ]
@@ -383,6 +391,8 @@ paths:
       schema:
         type: boolean
         default: false
+    # Using POST instead of PUT since jersey2 doesn't support PUT without body
+    # TODO: PF-2593 - Change to PUT if we override with moustache templating
     post:
       summary: Starts a GCP Dataproc cluster
       operationId: putDataprocClusterStart
@@ -409,6 +419,8 @@ paths:
       schema:
         type: boolean
         default: false
+    # Using POST instead of PUT since jersey2 doesn't support PUT without body
+    # TODO: PF-2593 - Change to PUT if we override with moustache templating
     post:
       summary: Stop a GCP Dataproc cluster
       operationId: putDataprocClusterStop

--- a/service/src/main/resources/api/openapi.yml
+++ b/service/src/main/resources/api/openapi.yml
@@ -383,7 +383,7 @@ paths:
       schema:
         type: boolean
         default: false
-    put:
+    post:
       summary: Starts a GCP Dataproc cluster
       operationId: putDataprocClusterStart
       tags: [ GcpResource ]
@@ -409,7 +409,7 @@ paths:
       schema:
         type: boolean
         default: false
-    put:
+    post:
       summary: Stop a GCP Dataproc cluster
       operationId: putDataprocClusterStop
       tags: [ GcpResource ]

--- a/service/src/test/java/bio/terra/axonserver/app/controller/AwsResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/axonserver/app/controller/AwsResourceControllerTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.axonserver.model.ApiNotebookStatus;
@@ -230,7 +230,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
     doReturn(notebook).when(awsResourceController).getNotebook(workspaceId, resourceId);
     doNothing().when(notebook).start(anyBoolean());
     mockMvc
-        .perform(put(operationPath).header("Authorization", String.format("bearer %s", fakeToken)))
+        .perform(post(operationPath).header("Authorization", String.format("bearer %s", fakeToken)))
         .andExpect(status().isOk());
 
     ArgumentCaptor<Boolean> waitCaptor = ArgumentCaptor.forClass(Boolean.class);
@@ -247,7 +247,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
     doNothing().when(notebook).start(anyBoolean());
     mockMvc
         .perform(
-            put(operationPath)
+            post(operationPath)
                 .header("Authorization", String.format("bearer %s", fakeToken))
                 .queryParam("wait", "true"))
         .andExpect(status().isOk());
@@ -265,7 +265,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
     doReturn(notebook).when(awsResourceController).getNotebook(workspaceId, resourceId);
     doNothing().when(notebook).stop(anyBoolean());
     mockMvc
-        .perform(put(operationPath).header("Authorization", String.format("bearer %s", fakeToken)))
+        .perform(post(operationPath).header("Authorization", String.format("bearer %s", fakeToken)))
         .andExpect(status().isOk());
 
     ArgumentCaptor<Boolean> waitCaptor = ArgumentCaptor.forClass(Boolean.class);
@@ -282,7 +282,7 @@ public class AwsResourceControllerTest extends BaseUnitTest {
     doNothing().when(notebook).stop(anyBoolean());
     mockMvc
         .perform(
-            put(operationPath)
+            post(operationPath)
                 .header("Authorization", String.format("bearer %s", fakeToken))
                 .queryParam("wait", "true"))
         .andExpect(status().isOk());

--- a/service/src/test/java/bio/terra/axonserver/app/controller/GcpResourceControllerTest.java
+++ b/service/src/test/java/bio/terra/axonserver/app/controller/GcpResourceControllerTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.axonserver.model.ApiClusterMetadata;
@@ -77,7 +77,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
     doReturn(notebook).when(gcpResourceController).getNotebook(workspaceId, resourceId);
     doNothing().when(notebook).start(anyBoolean());
     mockMvc
-        .perform(put(operationPath).header("Authorization", String.format("bearer %s", fakeToken)))
+        .perform(post(operationPath).header("Authorization", String.format("bearer %s", fakeToken)))
         .andExpect(status().isOk());
 
     ArgumentCaptor<Boolean> waitCaptor = ArgumentCaptor.forClass(Boolean.class);
@@ -94,7 +94,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
     doNothing().when(notebook).start(anyBoolean());
     mockMvc
         .perform(
-            put(operationPath)
+            post(operationPath)
                 .header("Authorization", String.format("bearer %s", fakeToken))
                 .queryParam("wait", "true"))
         .andExpect(status().isOk());
@@ -112,7 +112,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
     doReturn(notebook).when(gcpResourceController).getNotebook(workspaceId, resourceId);
     doNothing().when(notebook).stop(anyBoolean());
     mockMvc
-        .perform(put(operationPath).header("Authorization", String.format("bearer %s", fakeToken)))
+        .perform(post(operationPath).header("Authorization", String.format("bearer %s", fakeToken)))
         .andExpect(status().isOk());
 
     ArgumentCaptor<Boolean> waitCaptor = ArgumentCaptor.forClass(Boolean.class);
@@ -128,7 +128,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
     doReturn(notebook).when(gcpResourceController).getNotebook(workspaceId, resourceId);
     doNothing().when(notebook).stop(anyBoolean());
     mockMvc
-        .perform(addAuth(put(operationPath), USER_REQUEST).queryParam("wait", "true"))
+        .perform(addAuth(post(operationPath), USER_REQUEST).queryParam("wait", "true"))
         .andExpect(status().isOk());
 
     ArgumentCaptor<Boolean> waitCaptor = ArgumentCaptor.forClass(Boolean.class);
@@ -185,7 +185,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
     GoogleDataprocClusterUtil cluster = mock(GoogleDataprocClusterUtil.class);
     doReturn(cluster).when(gcpResourceController).getCluster(workspaceId, resourceId);
     doNothing().when(cluster).start(anyBoolean());
-    mockMvc.perform(addAuth(put(operationPath), USER_REQUEST)).andExpect(status().isOk());
+    mockMvc.perform(addAuth(post(operationPath), USER_REQUEST)).andExpect(status().isOk());
 
     ArgumentCaptor<Boolean> waitCaptor = ArgumentCaptor.forClass(Boolean.class);
     Mockito.verify(cluster).start(waitCaptor.capture());
@@ -200,7 +200,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
     doReturn(cluster).when(gcpResourceController).getCluster(workspaceId, resourceId);
     doNothing().when(cluster).start(anyBoolean());
     mockMvc
-        .perform(addAuth(put(operationPath), USER_REQUEST).queryParam("wait", "true"))
+        .perform(addAuth(post(operationPath), USER_REQUEST).queryParam("wait", "true"))
         .andExpect(status().isOk());
 
     ArgumentCaptor<Boolean> waitCaptor = ArgumentCaptor.forClass(Boolean.class);
@@ -215,7 +215,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
     GoogleDataprocClusterUtil cluster = mock(GoogleDataprocClusterUtil.class);
     doReturn(cluster).when(gcpResourceController).getCluster(workspaceId, resourceId);
     doNothing().when(cluster).stop(anyBoolean());
-    mockMvc.perform(addAuth(put(operationPath), USER_REQUEST)).andExpect(status().isOk());
+    mockMvc.perform(addAuth(post(operationPath), USER_REQUEST)).andExpect(status().isOk());
 
     ArgumentCaptor<Boolean> waitCaptor = ArgumentCaptor.forClass(Boolean.class);
     Mockito.verify(cluster).stop(waitCaptor.capture());
@@ -230,7 +230,7 @@ public class GcpResourceControllerTest extends BaseUnitTest {
     doReturn(cluster).when(gcpResourceController).getCluster(workspaceId, resourceId);
     doNothing().when(cluster).stop(anyBoolean());
     mockMvc
-        .perform(addAuth(put(operationPath), USER_REQUEST).queryParam("wait", "true"))
+        .perform(addAuth(post(operationPath), USER_REQUEST).queryParam("wait", "true"))
         .andExpect(status().isOk());
 
     ArgumentCaptor<Boolean> waitCaptor = ArgumentCaptor.forClass(Boolean.class);


### PR DESCRIPTION
The generated jersey2 swagger client does not allow empty request bodies in PUT requests. The notebook and cluster start/stop endpoints do this, but we don't have the workaround for this like WSM does [here](https://github.com/DataBiosphere/terra-workspace-manager/blob/440814262b6cb79e155dbf00205bd7e6896ee071/client/src/main/resources/swaggercodegen/libraries/jersey2/ApiClient.mustache#L700). For name, we use POST methods instead.

See: https://broadworkbench.atlassian.net/browse/PF-2953