### PR TITLE
Switch to pet SA key auth

### DIFF
--- a/service/src/main/java/bio/terra/axonserver/service/cromwellworkflow/CromwellWorkflowService.java
+++ b/service/src/main/java/bio/terra/axonserver/service/cromwellworkflow/CromwellWorkflowService.java
@@ -234,6 +234,7 @@ public class CromwellWorkflowService {
       String petSaKey = samService.getPetServiceAccountKey(projectId, userEmail, token);
       workflowOptions.put("user_service_account_json", petSaKey);
 
+      // Limit call caching to root bucket
       String[] cachePrefixes = {rootBucket.toString()};
       workflowOptions.put("call_cache_hit_path_prefixes", cachePrefixes);
       workflowOptions.put("google_project", projectId);

--- a/service/src/main/java/bio/terra/axonserver/service/cromwellworkflow/CromwellWorkflowService.java
+++ b/service/src/main/java/bio/terra/axonserver/service/cromwellworkflow/CromwellWorkflowService.java
@@ -228,9 +228,10 @@ public class CromwellWorkflowService {
       // Adjoin preset options for the options file.
       // Place the project ID + compute SA + docker image into the options.
       String projectId = wsmService.getGcpContext(workspaceId, token.getToken()).getProjectId();
+      String userEmail = samService.getUserStatusInfo(token).getUserEmail();
+      String petSaKey = samService.getPetServiceAccountKey(projectId, userEmail, token);
+      workflowOptions.put("user_service_account_json", petSaKey);
       workflowOptions.put("google_project", projectId);
-      workflowOptions.put(
-          "google_compute_service_account", samService.getPetServiceAccount(projectId, token));
       workflowOptions.put(
           "default_runtime_attributes",
           new AbstractMap.SimpleEntry<>("docker", "debian:stable-slim"));
@@ -240,7 +241,7 @@ public class CromwellWorkflowService {
       }
 
       labels.put(WORKSPACE_ID_LABEL_KEY, workspaceId.toString());
-      labels.put(USER_EMAIL_LABEL_KEY, samService.getUserStatusInfo(token).getUserEmail());
+      labels.put(USER_EMAIL_LABEL_KEY, userEmail);
       if (workflowGcsUri != null) {
         labels.put(GCS_SOURCE_LABEL_KEY, workflowGcsUri);
         InputStream inputStream =

--- a/service/src/main/java/bio/terra/axonserver/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/axonserver/service/iam/SamService.java
@@ -76,4 +76,15 @@ public class SamService {
       throw SamExceptionFactory.create("Error getting user's pet SA email.", apiException);
     }
   }
+
+  public String getPetServiceAccountKey(
+      String projectId, String userEmail, BearerToken userRequest) {
+    try {
+      return new GoogleApi(getApiClient(userRequest.getToken()))
+          .getUserPetServiceAccountKey(projectId, userEmail);
+    } catch (ApiException apiException) {
+      throw SamExceptionFactory.create(
+          "Error getting user's pet SA key for project.", apiException);
+    }
+  }
 }


### PR DESCRIPTION
Per [go/vwb-cromwell-v0](http://goto.google.com/vwb-cromwell-v0) - updating axon frontend server to use the user's pet service account key when submitting workflows to cromwell.

Also adds an option related to call caching