### PR TITLE
Use axon creds instead of user creds when grabbing user sa key

### DIFF
--- a/service/src/main/java/bio/terra/axonserver/service/cromwellworkflow/CromwellWorkflowService.java
+++ b/service/src/main/java/bio/terra/axonserver/service/cromwellworkflow/CromwellWorkflowService.java
@@ -228,9 +228,10 @@ public class CromwellWorkflowService {
       // Adjoin preset options for the options file.
       // Place the project ID + compute SA + docker image into the options.
       String projectId = wsmService.getGcpContext(workspaceId, token.getToken()).getProjectId();
+      String userEmail = samService.getUserStatusInfo(token).getUserEmail();
+      String petSaKey = samService.getPetServiceAccountKey(projectId, userEmail, token);
+      workflowOptions.put("user_service_account_json", petSaKey);
       workflowOptions.put("google_project", projectId);
-      workflowOptions.put(
-          "google_compute_service_account", samService.getPetServiceAccount(projectId, token));
       workflowOptions.put(
           "default_runtime_attributes",
           new AbstractMap.SimpleEntry<>("docker", "debian:stable-slim"));
@@ -240,7 +241,7 @@ public class CromwellWorkflowService {
       }
 
       labels.put(WORKSPACE_ID_LABEL_KEY, workspaceId.toString());
-      labels.put(USER_EMAIL_LABEL_KEY, samService.getUserStatusInfo(token).getUserEmail());
+      labels.put(USER_EMAIL_LABEL_KEY, userEmail);
       if (workflowGcsUri != null) {
         labels.put(GCS_SOURCE_LABEL_KEY, workflowGcsUri);
         InputStream inputStream =

--- a/service/src/main/java/bio/terra/axonserver/service/cromwellworkflow/CromwellWorkflowService.java
+++ b/service/src/main/java/bio/terra/axonserver/service/cromwellworkflow/CromwellWorkflowService.java
@@ -229,7 +229,7 @@ public class CromwellWorkflowService {
       // Place the project ID + compute SA + docker image into the options.
       String projectId = wsmService.getGcpContext(workspaceId, token.getToken()).getProjectId();
       String userEmail = samService.getUserStatusInfo(token).getUserEmail();
-      String petSaKey = samService.getPetServiceAccountKey(projectId, userEmail, token);
+      String petSaKey = samService.getPetServiceAccountKey(projectId, userEmail);
       workflowOptions.put("user_service_account_json", petSaKey);
       workflowOptions.put("google_project", projectId);
       workflowOptions.put(

--- a/service/src/main/java/bio/terra/axonserver/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/axonserver/service/iam/SamService.java
@@ -2,8 +2,13 @@ package bio.terra.axonserver.service.iam;
 
 import bio.terra.axonserver.app.configuration.SamConfiguration;
 import bio.terra.axonserver.service.cloud.gcp.GcpService;
+import bio.terra.common.exception.InternalServerErrorException;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.sam.exception.SamExceptionFactory;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.Set;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
 import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
@@ -15,6 +20,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class SamService {
 
+  private static final Set<String> SAM_OAUTH_SCOPES = ImmutableSet.of("openid", "email", "profile");
   private final SamConfiguration samConfig;
 
   @Autowired
@@ -77,14 +83,25 @@ public class SamService {
     }
   }
 
-  public String getPetServiceAccountKey(
-      String projectId, String userEmail, BearerToken userRequest) {
+  public String getPetServiceAccountKey(String projectId, String userEmail) {
     try {
-      return new GoogleApi(getApiClient(userRequest.getToken()))
+      return new GoogleApi(getApiClient(getAxonServiceAccountToken()))
           .getUserPetServiceAccountKey(projectId, userEmail);
     } catch (ApiException apiException) {
       throw SamExceptionFactory.create(
           "Error getting user's pet SA key for project.", apiException);
+    }
+  }
+
+  public String getAxonServiceAccountToken() {
+    try {
+      GoogleCredentials creds =
+          GoogleCredentials.getApplicationDefault().createScoped(SAM_OAUTH_SCOPES);
+      creds.refreshIfExpired();
+      return creds.getAccessToken().getTokenValue();
+    } catch (IOException e) {
+      throw new InternalServerErrorException(
+          "Internal server error retrieving axon credentials", e);
     }
   }
 }

--- a/service/src/main/java/bio/terra/axonserver/service/iam/SamService.java
+++ b/service/src/main/java/bio/terra/axonserver/service/iam/SamService.java
@@ -76,4 +76,15 @@ public class SamService {
       throw SamExceptionFactory.create("Error getting user's pet SA email.", apiException);
     }
   }
+
+  public String getPetServiceAccountKey(
+      String projectId, String userEmail, BearerToken userRequest) {
+    try {
+      return new GoogleApi(getApiClient(userRequest.getToken()))
+          .getUserPetServiceAccountKey(projectId, userEmail);
+    } catch (ApiException apiException) {
+      throw SamExceptionFactory.create(
+          "Error getting user's pet SA key for project.", apiException);
+    }
+  }
 }


### PR DESCRIPTION
Didn't catch this issue because we developers have broad permissions in dev, so using our own permissions works.