### PR TITLE
Add logs and file permissions for downloaded deps

### DIFF
--- a/service/src/main/java/bio/terra/axonserver/utils/AutoDeletingTempDir.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/AutoDeletingTempDir.java
@@ -34,7 +34,7 @@ public class AutoDeletingTempDir implements AutoCloseable {
 
   @Override
   public void close() throws IOException {
-    logger.info("Deleting AutoDeletingTempDir {}", dir.toString());
+    logger.info("Deleting AutoDeletingTempDir {}", dir);
     Files.walkFileTree(
         dir, EnumSet.noneOf(FileVisitOption.class), Integer.MAX_VALUE, new DeletionFileVisitor());
   }

--- a/service/src/main/java/bio/terra/axonserver/utils/AutoDeletingTempDir.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/AutoDeletingTempDir.java
@@ -9,9 +9,14 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.EnumSet;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** A tmp directory that will auto delete. For use in try-with-resources blocks. */
 public class AutoDeletingTempDir implements AutoCloseable {
+
+  private static final Logger logger = LoggerFactory.getLogger(AutoDeletingTempDir.class);
+
   private final Path dir;
 
   /**
@@ -29,6 +34,7 @@ public class AutoDeletingTempDir implements AutoCloseable {
 
   @Override
   public void close() throws IOException {
+    logger.info("Deleting AutoDeletingTempDir {}", dir.toString());
     Files.walkFileTree(
         dir, EnumSet.noneOf(FileVisitOption.class), Integer.MAX_VALUE, new DeletionFileVisitor());
   }

--- a/service/src/main/java/bio/terra/axonserver/utils/AutoDeletingTempFile.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/AutoDeletingTempFile.java
@@ -32,7 +32,7 @@ public class AutoDeletingTempFile implements AutoCloseable {
 
   @Override
   public void close() throws IOException {
-    logger.info("Deleting AutoDeletingTempFile {}", file.toString());
+    logger.info("Deleting AutoDeletingTempFile {}", file);
     Files.deleteIfExists(file.toPath());
   }
 }

--- a/service/src/main/java/bio/terra/axonserver/utils/AutoDeletingTempFile.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/AutoDeletingTempFile.java
@@ -8,8 +8,11 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
 import org.apache.commons.lang3.SystemUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AutoDeletingTempFile implements AutoCloseable {
+  private static final Logger logger = LoggerFactory.getLogger(AutoDeletingTempFile.class);
   private final File file;
 
   public AutoDeletingTempFile(String filePrefix, String fileSuffix) throws IOException {
@@ -29,6 +32,7 @@ public class AutoDeletingTempFile implements AutoCloseable {
 
   @Override
   public void close() throws IOException {
+    logger.info("Deleting AutoDeletingTempFile {}", file.toString());
     Files.deleteIfExists(file.toPath());
   }
 }

--- a/service/src/main/java/bio/terra/axonserver/utils/CloudStorageUtils.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/CloudStorageUtils.java
@@ -109,7 +109,6 @@ public class CloudStorageUtils {
         logger.info("Local file path: {}", localFile.getPath());
 
         if (!localFile.getParentFile().mkdirs() && !localFile.getParentFile().exists()) {
-          logger.error("Error creating local directory");
           throw new RuntimeException("Error creating local directory for downloaded dependency");
         }
 
@@ -119,7 +118,6 @@ public class CloudStorageUtils {
           Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwx------");
           Files.setPosixFilePermissions(localFile.toPath(), perms);
         } catch (IOException e) {
-          logger.error("IO error: {}", e.getMessage());
           throw new RuntimeException("Error downloading dependency: " + e);
         }
       }

--- a/service/src/main/java/bio/terra/axonserver/utils/CloudStorageUtils.java
+++ b/service/src/main/java/bio/terra/axonserver/utils/CloudStorageUtils.java
@@ -15,10 +15,16 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.Channels;
+import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpRange;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
@@ -26,6 +32,7 @@ import org.springframework.web.client.HttpClientErrorException;
 
 /** Service for interacting with Google Cloud Storage */
 public class CloudStorageUtils {
+  private static final Logger logger = LoggerFactory.getLogger(CloudStorageUtils.class);
 
   /**
    * Get the contents of a GCS bucket object
@@ -83,29 +90,41 @@ public class CloudStorageUtils {
       String filterSuffix) {
     Storage gcs =
         StorageOptions.newBuilder().setCredentials(googleCredentials).build().getService();
+
+    logger.info("Listing blobs in bucket {} with prefix: {}", bucketName, directoryPath);
     Page<Blob> blobs = gcs.list(bucketName, BlobListOption.prefix(directoryPath));
+
+    logger.info("Iterating over blobs");
     for (Blob blob : blobs.iterateAll()) {
       String blobName = blob.getName();
       if (blobName.endsWith(filterSuffix)) {
+        logger.info("Blob matches filter, fetching: {}", blobName);
         Blob blobToRead = gcs.get(BlobId.of(bucketName, blobName));
         byte[] content = blobToRead.getContent();
 
         String relativePath = blobName.substring(directoryPath.length());
+        logger.info("Relative path for blob: {}", relativePath);
+
         File localFile = Paths.get(localDestination, relativePath).toFile();
+        logger.info("Local file path: {}", localFile.getPath());
+
         if (!localFile.getParentFile().mkdirs() && !localFile.getParentFile().exists()) {
+          logger.error("Error creating local directory");
           throw new RuntimeException("Error creating local directory for downloaded dependency");
         }
-        ;
 
         try (FileOutputStream fos = new FileOutputStream(localFile)) {
+          logger.info("Writing blob content to file");
           fos.write(content);
+          Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwx------");
+          Files.setPosixFilePermissions(localFile.toPath(), perms);
         } catch (IOException e) {
+          logger.error("IO error: {}", e.getMessage());
           throw new RuntimeException("Error downloading dependency: " + e);
         }
       }
     }
   }
-
   /**
    * Parse a bucket name and object name from a gcs URI
    *


### PR DESCRIPTION
Seeing an issue in dev where WOMTool in AFS is failing to read downloaded dependencies. Can't reproduce locally. Adding logs and a few file permissions for debugging in dev 

Error: https://pantheon.corp.google.com/logs/query;cursorTimestamp=2023-09-28T15:43:14.454Z;endTime=2023-09-28T16:48:40.458Z;query=resource.labels.namespace_name%3D%22axon%22%0Atimestamp%3D%222023-09-28T15:43:14.454Z%22%0AinsertId%3D%22th5jtheh83wqjtbp%22;startTime=2023-09-28T14:43:13.397814Z?project=terra-devel